### PR TITLE
Remove side effects of Router

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -38,6 +38,9 @@ func NewRouter() *Router {
 type Router struct {
 	// Configurable Handler to be used when no route matches.
 	NotFoundHandler http.Handler
+	// If true, the request's context will not be wiped once
+	// the router is done
+	KeepContext bool
 	// Parent route, if this is a subrouter.
 	parent parentRoute
 	// Routes to be matched, in order.
@@ -82,7 +85,9 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		handler = r.NotFoundHandler
 	}
-	defer context.Clear(req)
+	if !r.KeepContext {
+		defer context.Clear(req)
+	}
 	handler.ServeHTTP(w, req)
 }
 

--- a/route.go
+++ b/route.go
@@ -352,6 +352,9 @@ func (r *Route) Schemes(schemes ...string) *Route {
 // doesn't match.
 func (r *Route) Subrouter() *Router {
 	router := &Router{parent: r, strictSlash: r.strictSlash}
+	if parentRouter, ok := r.parent.(*Router); ok && parentRouter != nil {
+		router.KeepContext = parentRouter.KeepContext
+	}
 	r.addMatcher(router)
 	return router
 }


### PR DESCRIPTION
Sometimes I uses cascades of muxers to keep code modules decoupled (e.g. a stand-alone OAuth module, which is an `http.Handler` and uses Gorilla's `Router` internally, but is sometimes attached to an existing `Router`).

I have encountered situations, though,  in which I share  `context` across these cascaded routers. (I put a  [small, constructed example](https://gist.github.com/4245799) in a gist).

My proposal for solving this is this pull request, in which you can define wether a `Router` will wipe the request's context once it has finished routing. The new property `KeepContext` is propagated to subrouters.

(My first solutions to just remove the automatic context wiping alltogether, but I figured it might break a lot of existing programs.)

I am, however, open to other/better solutions to this problem ;) 
