### PR TITLE
Test and fix for dealing with path regexes with multiple subexpressions

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -194,6 +194,15 @@ func TestPath(t *testing.T) {
 			path:        "/111/222/333",
 			shouldMatch: false,
 		},
+		{
+			title:       "Path route with multiple complex patterns, URL in request does match",
+			route:       new(Route).Path("/{v1:\\d+(-\\d+)?(:\\d+(-\\d+)?)*}/{v2:\\d+(-\\d+)?(:\\d+(-\\d+)?)*}"),
+			request:     newRequest("GET", "http://localhost/1-3:5/8-10:23"),
+			vars:        map[string]string{"v1": "1-3:5", "v2": "8-10:23"},
+			host:        "",
+			path:        "/1-3:5/8-10:23",
+			shouldMatch: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Hi Rodrigo,

I've been using mux to do some fairly complicated regex matching with multiple named patterns containing multiple subexpressions. This fix and test covers my use case. Let me know if you want any more tests or the same treatment for host regexes.

Cheers,
Donovan.