### PR TITLE
Fix %2F inside route parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,2 @@
 mux
 ===
-
-gorilla/mux is a powerful URL router and dispatcher.
-
-Read the full documentation here: http://www.gorillatoolkit.org/pkg/mux

--- a/doc.go
+++ b/doc.go
@@ -87,9 +87,7 @@ There are several other matchers that can be added. To match path prefixes:
 
 ...or to use a custom matcher function:
 
-	r.MatcherFunc(func(r *http.Request, rm *RouteMatch) bool {
-		return r.ProtoMajor == 0
-    })
+	r.MatcherFunc(myFunc)
 
 ...and finally, it is possible to combine several matchers in a single route:
 

--- a/mux.go
+++ b/mux.go
@@ -51,7 +51,7 @@ type Router struct {
 // Match matches registered routes against the request.
 func (r *Router) Match(req *http.Request, match *RouteMatch) bool {
 	for _, route := range r.routes {
-		if route.Match(req, match) {
+		if matched := route.Match(req, match); matched {
 			return true
 		}
 	}
@@ -71,7 +71,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	var match RouteMatch
 	var handler http.Handler
-	if r.Match(req, &match) {
+	if matched := r.Match(req, &match); matched {
 		handler = match.Handler
 		setVars(req, match.Vars)
 		setCurrentRoute(req, match.Route)

--- a/mux_test.go
+++ b/mux_test.go
@@ -194,6 +194,15 @@ func TestPath(t *testing.T) {
 			path:        "/111/222/333",
 			shouldMatch: false,
 		},
+		{
+			title:       "Path route with multiple complex patterns, URL in request does match",
+			route:       new(Route).Path("/{v1:\\d+(-\\d+)?(:\\d+(-\\d+)?)*}/{v2:\\d+(-\\d+)?(:\\d+(-\\d+)?)*}"),
+			request:     newRequest("GET", "http://localhost/1-3:5/8-10:23"),
+			vars:        map[string]string{"v1": "1-3:5", "v2": "8-10:23"},
+			host:        "",
+			path:        "/1-3:5/8-10:23",
+			shouldMatch: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/regexp.go
+++ b/regexp.go
@@ -47,11 +47,13 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, strictSlash bool) (*rout
 		endSlash = true
 	}
 	varsN := make([]string, len(idxs)/2)
+	varsI := make([]int, len(idxs)/2)
 	varsR := make([]*regexp.Regexp, len(idxs)/2)
 	pattern := bytes.NewBufferString("^")
 	reverse := bytes.NewBufferString("")
 	var end int
 	var err error
+	subExpIndex := 1
 	for i := 0; i < len(idxs); i += 2 {
 		// Set all values we are interested in.
 		raw := tpl[end:idxs[i]]
@@ -74,6 +76,8 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, strictSlash bool) (*rout
 		// Append variable name and compiled pattern.
 		varsN[i/2] = name
 		varsR[i/2], err = regexp.Compile(fmt.Sprintf("^%s$", patt))
+		varsI[i/2] = subExpIndex
+		subExpIndex += varsR[i/2].NumSubexp() + 1
 		if err != nil {
 			return nil, err
 		}
@@ -104,6 +108,7 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, strictSlash bool) (*rout
 		reverse:   reverse.String(),
 		varsN:     varsN,
 		varsR:     varsR,
+		varsI:     varsI,
 	}, nil
 }
 
@@ -120,6 +125,8 @@ type routeRegexp struct {
 	reverse string
 	// Variable names.
 	varsN []string
+	// Subexpression indexes
+	varsI []int
 	// Variable regexps (validators).
 	varsR []*regexp.Regexp
 }

--- a/regexp.go
+++ b/regexp.go
@@ -222,7 +222,12 @@ func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) 
 		pathVars := v.path.regexp.FindStringSubmatch(uri)
 		if pathVars != nil {
 			for i, n := range v.path.varsN {
-				m.Vars[n] = pathVars[v.path.varsI[i]]
+				varN := pathVars[v.path.varsI[i]]
+				var err error
+				m.Vars[n], err = url.QueryUnescape(varN)
+				if err != nil {
+					m.Vars[n] = varN
+				}
 			}
 			// Check if we should redirect.
 			if r.strictSlash {

--- a/regexp.go
+++ b/regexp.go
@@ -221,8 +221,8 @@ func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) 
 	if v.path != nil {
 		pathVars := v.path.regexp.FindStringSubmatch(uri)
 		if pathVars != nil {
-			for k, v := range v.path.varsN {
-				m.Vars[v] = pathVars[k+1]
+			for i, n := range v.path.varsN {
+				m.Vars[n] = pathVars[v.path.varsI[i]]
 			}
 			// Check if we should redirect.
 			if r.strictSlash {

--- a/regexp.go
+++ b/regexp.go
@@ -126,8 +126,9 @@ type routeRegexp struct {
 
 // Match matches the regexp against the URL host or path.
 func (r *routeRegexp) Match(req *http.Request, match *RouteMatch) bool {
+	uri := strings.Split(req.RequestURI, "?")[0]
 	if !r.matchHost {
-		return r.regexp.MatchString(req.URL.Path)
+		return r.regexp.MatchString(uri)
 	}
 	return r.regexp.MatchString(getHost(req))
 }
@@ -199,6 +200,7 @@ type routeRegexpGroup struct {
 
 // setMatch extracts the variables from the URL once a route matches.
 func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) {
+	uri := strings.Split(req.RequestURI, "?")[0]
 	// Store host variables.
 	if v.host != nil {
 		hostVars := v.host.regexp.FindStringSubmatch(getHost(req))
@@ -210,14 +212,14 @@ func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) 
 	}
 	// Store path variables.
 	if v.path != nil {
-		pathVars := v.path.regexp.FindStringSubmatch(req.URL.Path)
+		pathVars := v.path.regexp.FindStringSubmatch(uri)
 		if pathVars != nil {
 			for k, v := range v.path.varsN {
 				m.Vars[v] = pathVars[k+1]
 			}
 			// Check if we should redirect.
 			if r.strictSlash {
-				p1 := strings.HasSuffix(req.URL.Path, "/")
+				p1 := strings.HasSuffix(uri, "/")
 				p2 := strings.HasSuffix(v.path.template, "/")
 				if p1 != p2 {
 					u, _ := url.Parse(req.URL.String())


### PR DESCRIPTION
As mux routes match against the request's URL.Path, which get %2F transformed into /, %2F inside parameters don't work as expected. This fixes it by sing the request's RequestURI instead.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gorilla/mux/22)
<!-- Reviewable:end -->
