### PR TITLE
Optional Clearing Context

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -14,7 +14,7 @@ import (
 
 // NewRouter returns a new router instance.
 func NewRouter() *Router {
-    return &Router{namedRoutes: make(map[string]*Route), KeepContext: false,}
+	return &Router{namedRoutes: make(map[string]*Route), KeepContext: false}
 }
 
 // Router registers routes to be matched and dispatches a handler.
@@ -46,8 +46,8 @@ type Router struct {
 	namedRoutes map[string]*Route
 	// See Router.StrictSlash(). This defines the flag for new routes.
 	strictSlash bool
-    // If true, do not clear the the request context after handling the request
-    KeepContext bool
+	// If true, do not clear the the request context after handling the request
+	KeepContext bool
 }
 
 // Match matches registered routes against the request.
@@ -84,9 +84,9 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		handler = r.NotFoundHandler
 	}
-    if !r.KeepContext {
-        defer context.Clear(req)
-    }
+	if !r.KeepContext {
+		defer context.Clear(req)
+	}
 	handler.ServeHTTP(w, req)
 }
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -667,24 +667,24 @@ func TestKeepContext(t *testing.T) {
 	r.HandleFunc("/", func1).Name("func1")
 
 	req, _ := http.NewRequest("GET", "http://localhost/", nil)
-    context.Set(req, "t", 1)
-    
-    res := new(http.ResponseWriter)
-    r.ServeHTTP(*res, req)
+	context.Set(req, "t", 1)
 
-    if _, ok := context.GetOk(req, "t"); ok {
-        t.Error("Context should have been cleared at end of request")
-    }
+	res := new(http.ResponseWriter)
+	r.ServeHTTP(*res, req)
 
-    r.KeepContext = true
+	if _, ok := context.GetOk(req, "t"); ok {
+		t.Error("Context should have been cleared at end of request")
+	}
+
+	r.KeepContext = true
 
 	req, _ = http.NewRequest("GET", "http://localhost/", nil)
-    context.Set(req, "t", 1)
+	context.Set(req, "t", 1)
 
-    r.ServeHTTP(*res, req)
-    if _, ok := context.GetOk(req, "t"); !ok {
-        t.Error("Context should NOT have been cleared at end of request")
-    }
+	r.ServeHTTP(*res, req)
+	if _, ok := context.GetOk(req, "t"); !ok {
+		t.Error("Context should NOT have been cleared at end of request")
+	}
 
 }
 


### PR DESCRIPTION
I am submitting this pull request for optionally turning off clearing of the request context variables for a router.  

I am finding that while working with mux, I may want to dispatch all of my calls through a single top-level handler.  When this happens, I would like to handle some things, such as errors, after the internal mux router ServeHTTP method.  For example, I might do something like this:

```
http.HandleFunc("/", func (w http.ResponseWriter, r *http.Request) {
    // Set up context variables for request
    // Defer Clear

    router.ServeHTTP(w, r)

    // HERE - I want to work with the context variables
})
```

So, I am submitting this pull request.  I hope you find it adds value to the project and accept it.  

I've added a new test as well, in mux_test.go.  It tests both the clearing and disabling of the clearing.
