### PR TITLE
Better error messages

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"path"
-	"strings"
 
 	"github.com/gorilla/context"
 )
@@ -339,32 +338,6 @@ func matchMap(toCheck map[string]string, toMatch map[string][]string,
 	return true
 }
 
-// Pretty-Prints map[string]string to a pretty formatted string
-func mapToString(m map[string]string) string {
-	output := []string{}
-	for key, val := range m {
-		entry := key
-		if val != "" {
-			entry += "=" + val
-		}
-		output = append(output, entry)
-	}
-	return strings.Join(output, ", ")
-}
-
-// Pretty-Prints map[string][]string to a pretty formatted string
-func mapListToString(m map[string][]string) string {
-	output := []string{}
-	for key, val := range m {
-		entry := key
-		if val != nil {
-			entry += "=" + strings.Join(val, "|")
-		}
-		output = append(output, entry)
-	}
-	return strings.Join(output, ", ")
-}
-
 // This structure captures error information in the case where a route
 // isn't matched. By default, an unmatched route would just return a 404,
 // however, in some cases we need to give other error information. By creating
@@ -376,7 +349,7 @@ type MatchError struct {
 	// Response body on error
 	Body string
 	// Headers to set on error
-	Headers http.Header
+	Header http.Header
 }
 
 // Default handler for when a URL was not matched
@@ -388,10 +361,10 @@ func NotFound(w http.ResponseWriter, r *http.Request) {
 			matchStruct.Code = 404
 		}
 
-		if len(matchStruct.Headers) > 0 {
+		if len(matchStruct.Header) > 0 {
 			// If we have headers associated to this match struct, we will merge them
 			// to the current headers in the response Header dictionary
-			for header, values := range matchStruct.Headers {
+			for header, values := range matchStruct.Header {
 				for idx := range values {
 					w.Header().Add(header, values[idx])
 				}

--- a/mux_test.go
+++ b/mux_test.go
@@ -706,7 +706,7 @@ func TestNoMatchMethodErrors(t *testing.T) {
 		t.Error("No proper error context returned for missing header")
 	} else if matchErr.Code != 405 {
 		t.Error("Improper error code for header match")
-	} else if len(matchErr.Headers) == 0 {
+	} else if len(matchErr.Header) == 0 {
 		t.Error("Allow header not properly set when methods don't match")
 	}
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+
+	"github.com/gorilla/context"
 )
 
 type routeTest struct {
@@ -653,6 +655,152 @@ func testRoute(t *testing.T, test routeTest) {
 				return
 			}
 		}
+	}
+}
+
+func TestNoMatchHeaderErrors(t *testing.T) {
+	func1 := func(w http.ResponseWriter, r *http.Request) {}
+
+	r := NewRouter()
+	s := r.Headers(
+        "SomeSpecialHeader", "", "SomeSpecialHeader1", "a").Subrouter()
+	s.HandleFunc("/", func1).Name("func1")
+
+	req, _ := http.NewRequest("GET", "http://localhost/", nil)
+	match := new(RouteMatch)
+	matched := r.Match(req, match)
+
+    if matched {
+        t.Error("Should not have matched route for headers")
+    }
+
+    if _, ok := context.GetOk(req, MatchErrMsgKey); !ok {
+        t.Error("No proper error msg returned for missing header")
+    }
+    if code, ok := context.Get(req, MatchErrCodeKey).(int); !ok {
+        t.Error("No proper error code returned for missing header")
+    } else if code != 412 {
+        t.Error("Improper error code for header match")
+    }
+
+	resp := NewRecorder()
+	r.ServeHTTP(resp, req)
+	if resp.Code != 412 {
+		t.Errorf("Expecting code %s", 412)
+	}
+}
+
+func TestNoMatchMethodErrors(t *testing.T) {
+	func1 := func(w http.ResponseWriter, r *http.Request) {}
+
+    r := NewRouter()
+    s := r.Methods("GET", "POST").Subrouter()
+	s.HandleFunc("/", func1).Name("func1")
+
+    req, _ := http.NewRequest("PUT", "http://localhost/", nil)
+    match := new(RouteMatch)
+    matched := r.Match(req, match)
+
+    if matched {
+        t.Error("Should not have matched route for methods")
+    }
+
+    if _, ok := context.GetOk(req, MatchErrMsgKey); !ok {
+        t.Error("No proper error msg returned for incorrect method")
+    }
+    if code, ok := context.Get(req, MatchErrCodeKey).(int); !ok {
+        t.Error("No proper error code returned for incorrect method")
+    } else if code != 405 {
+        t.Error("Improper error code for method match")
+    }
+
+	resp := NewRecorder()
+	r.ServeHTTP(resp, req)
+	if resp.Code != 405 {
+		t.Errorf("Expecting code %s", 405)
+	}
+}
+
+func TestNoMatchQueryErrors(t *testing.T) {
+	func1 := func(w http.ResponseWriter, r *http.Request) {}
+
+    r := NewRouter()
+    s := r.Queries("x", "").Subrouter()
+	s.HandleFunc("/", func1).Name("func1")
+
+    req, _ := http.NewRequest("GET", "http://localhost/", nil)
+    match := new(RouteMatch)
+    matched := r.Match(req, match)
+
+    if matched {
+        t.Error("Should not have matched route for queries")
+    }
+
+    if _, ok := context.GetOk(req, MatchErrMsgKey); !ok {
+        t.Error("No proper error msg returned for missing queries")
+    }
+    if code, ok := context.Get(req, MatchErrCodeKey).(int); !ok {
+        t.Error("No proper error code returned for missing queries")
+    } else if code != 412 {
+        t.Error("Improper error code for query match")
+    }
+
+	resp := NewRecorder()
+	r.ServeHTTP(resp, req)
+	if resp.Code != 412 {
+		t.Errorf("Expecting code %s", 412)
+	}
+}
+
+func TestNoMatchSchemeErrors(t *testing.T) {
+	func1 := func(w http.ResponseWriter, r *http.Request) {}
+
+    r := NewRouter()
+    s := r.Schemes("https").Subrouter()
+	s.HandleFunc("/", func1).Name("func1")
+
+    req, _ := http.NewRequest("GET", "http://localhost/", nil)
+    match := new(RouteMatch)
+    matched := r.Match(req, match)
+
+    if matched {
+        t.Error("Should not have matched route for scheme")
+    }
+
+    if _, ok := context.GetOk(req, MatchErrMsgKey); !ok {
+        t.Error("No proper error msg returned for incorrect scheme")
+    }
+    if code, ok := context.Get(req, MatchErrCodeKey).(int); !ok {
+        t.Error("No proper error code returned for incorrect scheme")
+    } else if code != 403 {
+        t.Error("Improper error code for scheme match")
+    }
+
+	resp := NewRecorder()
+	r.ServeHTTP(resp, req)
+	if resp.Code != 403 {
+		t.Errorf("Expecting code %s", 403)
+	}
+}
+
+func TestNoMatchPathErrors(t *testing.T) {
+	func1 := func(w http.ResponseWriter, r *http.Request) {}
+
+    r := NewRouter()
+	r.HandleFunc("/foo", func1).Name("func1")
+
+    req, _ := http.NewRequest("GET", "http://localhost/", nil)
+    match := new(RouteMatch)
+    matched := r.Match(req, match)
+
+    if matched {
+        t.Error("Should not have matched route for scheme")
+    }
+
+	resp := NewRecorder()
+	r.ServeHTTP(resp, req)
+	if resp.Code != 404 {
+		t.Errorf("Expecting code %s", 404)
 	}
 }
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -663,25 +663,22 @@ func TestNoMatchHeaderErrors(t *testing.T) {
 
 	r := NewRouter()
 	s := r.Headers(
-        "SomeSpecialHeader", "", "SomeSpecialHeader1", "a").Subrouter()
+		"SomeSpecialHeader", "", "SomeSpecialHeader1", "a").Subrouter()
 	s.HandleFunc("/", func1).Name("func1")
 
 	req, _ := http.NewRequest("GET", "http://localhost/", nil)
 	match := new(RouteMatch)
 	matched := r.Match(req, match)
 
-    if matched {
-        t.Error("Should not have matched route for headers")
-    }
+	if matched {
+		t.Error("Should not have matched route for headers")
+	}
 
-    if _, ok := context.GetOk(req, MatchErrMsgKey); !ok {
-        t.Error("No proper error msg returned for missing header")
-    }
-    if code, ok := context.Get(req, MatchErrCodeKey).(int); !ok {
-        t.Error("No proper error code returned for missing header")
-    } else if code != 412 {
-        t.Error("Improper error code for header match")
-    }
+	if matchErr, ok := context.Get(req, MuxMatchErrorContextKey).(MatchError); !ok {
+		t.Error("No proper error context returned for missing header")
+	} else if matchErr.Code != 412 {
+		t.Error("Improper error code for header match")
+	}
 
 	resp := NewRecorder()
 	r.ServeHTTP(resp, req)
@@ -693,26 +690,25 @@ func TestNoMatchHeaderErrors(t *testing.T) {
 func TestNoMatchMethodErrors(t *testing.T) {
 	func1 := func(w http.ResponseWriter, r *http.Request) {}
 
-    r := NewRouter()
-    s := r.Methods("GET", "POST").Subrouter()
+	r := NewRouter()
+	s := r.Methods("GET", "POST").Subrouter()
 	s.HandleFunc("/", func1).Name("func1")
 
-    req, _ := http.NewRequest("PUT", "http://localhost/", nil)
-    match := new(RouteMatch)
-    matched := r.Match(req, match)
+	req, _ := http.NewRequest("PUT", "http://localhost/", nil)
+	match := new(RouteMatch)
+	matched := r.Match(req, match)
 
-    if matched {
-        t.Error("Should not have matched route for methods")
-    }
+	if matched {
+		t.Error("Should not have matched route for methods")
+	}
 
-    if _, ok := context.GetOk(req, MatchErrMsgKey); !ok {
-        t.Error("No proper error msg returned for incorrect method")
-    }
-    if code, ok := context.Get(req, MatchErrCodeKey).(int); !ok {
-        t.Error("No proper error code returned for incorrect method")
-    } else if code != 405 {
-        t.Error("Improper error code for method match")
-    }
+	if matchErr, ok := context.Get(req, MuxMatchErrorContextKey).(MatchError); !ok {
+		t.Error("No proper error context returned for missing header")
+	} else if matchErr.Code != 405 {
+		t.Error("Improper error code for header match")
+	} else if len(matchErr.Headers) == 0 {
+		t.Error("Allow header not properly set when methods don't match")
+	}
 
 	resp := NewRecorder()
 	r.ServeHTTP(resp, req)
@@ -724,26 +720,23 @@ func TestNoMatchMethodErrors(t *testing.T) {
 func TestNoMatchQueryErrors(t *testing.T) {
 	func1 := func(w http.ResponseWriter, r *http.Request) {}
 
-    r := NewRouter()
-    s := r.Queries("x", "").Subrouter()
+	r := NewRouter()
+	s := r.Queries("x", "").Subrouter()
 	s.HandleFunc("/", func1).Name("func1")
 
-    req, _ := http.NewRequest("GET", "http://localhost/", nil)
-    match := new(RouteMatch)
-    matched := r.Match(req, match)
+	req, _ := http.NewRequest("GET", "http://localhost/", nil)
+	match := new(RouteMatch)
+	matched := r.Match(req, match)
 
-    if matched {
-        t.Error("Should not have matched route for queries")
-    }
+	if matched {
+		t.Error("Should not have matched route for queries")
+	}
 
-    if _, ok := context.GetOk(req, MatchErrMsgKey); !ok {
-        t.Error("No proper error msg returned for missing queries")
-    }
-    if code, ok := context.Get(req, MatchErrCodeKey).(int); !ok {
-        t.Error("No proper error code returned for missing queries")
-    } else if code != 412 {
-        t.Error("Improper error code for query match")
-    }
+	if matchErr, ok := context.Get(req, MuxMatchErrorContextKey).(MatchError); !ok {
+		t.Error("No proper error context returned for missing header")
+	} else if matchErr.Code != 412 {
+		t.Error("Improper error code for header match")
+	}
 
 	resp := NewRecorder()
 	r.ServeHTTP(resp, req)
@@ -755,26 +748,23 @@ func TestNoMatchQueryErrors(t *testing.T) {
 func TestNoMatchSchemeErrors(t *testing.T) {
 	func1 := func(w http.ResponseWriter, r *http.Request) {}
 
-    r := NewRouter()
-    s := r.Schemes("https").Subrouter()
+	r := NewRouter()
+	s := r.Schemes("https").Subrouter()
 	s.HandleFunc("/", func1).Name("func1")
 
-    req, _ := http.NewRequest("GET", "http://localhost/", nil)
-    match := new(RouteMatch)
-    matched := r.Match(req, match)
+	req, _ := http.NewRequest("GET", "http://localhost/", nil)
+	match := new(RouteMatch)
+	matched := r.Match(req, match)
 
-    if matched {
-        t.Error("Should not have matched route for scheme")
-    }
+	if matched {
+		t.Error("Should not have matched route for scheme")
+	}
 
-    if _, ok := context.GetOk(req, MatchErrMsgKey); !ok {
-        t.Error("No proper error msg returned for incorrect scheme")
-    }
-    if code, ok := context.Get(req, MatchErrCodeKey).(int); !ok {
-        t.Error("No proper error code returned for incorrect scheme")
-    } else if code != 403 {
-        t.Error("Improper error code for scheme match")
-    }
+	if matchErr, ok := context.Get(req, MuxMatchErrorContextKey).(MatchError); !ok {
+		t.Error("No proper error context returned for missing header")
+	} else if matchErr.Code != 403 {
+		t.Error("Improper error code for header match")
+	}
 
 	resp := NewRecorder()
 	r.ServeHTTP(resp, req)
@@ -786,16 +776,16 @@ func TestNoMatchSchemeErrors(t *testing.T) {
 func TestNoMatchPathErrors(t *testing.T) {
 	func1 := func(w http.ResponseWriter, r *http.Request) {}
 
-    r := NewRouter()
+	r := NewRouter()
 	r.HandleFunc("/foo", func1).Name("func1")
 
-    req, _ := http.NewRequest("GET", "http://localhost/", nil)
-    match := new(RouteMatch)
-    matched := r.Match(req, match)
+	req, _ := http.NewRequest("GET", "http://localhost/", nil)
+	match := new(RouteMatch)
+	matched := r.Match(req, match)
 
-    if matched {
-        t.Error("Should not have matched route for scheme")
-    }
+	if matched {
+		t.Error("Should not have matched route for scheme")
+	}
 
 	resp := NewRecorder()
 	r.ServeHTTP(resp, req)

--- a/route.go
+++ b/route.go
@@ -185,11 +185,8 @@ func (m headerMatcher) Match(r *http.Request, match *RouteMatch) bool {
 		if received == "" {
 			received = "(NONE)"
 		}
-		body := fmt.Sprint(
-			"Required Headers Missing.\nReceived: ", received,
-			"\nMandatory Headers: ", mapToString(map[string]string(m)))
 
-		context.Set(r, MuxMatchErrorContextKey, MatchError{Code: 412, Body: body})
+		context.Set(r, MuxMatchErrorContextKey, MatchError{Code: 412})
 	}
 	return isMatch
 }
@@ -321,10 +318,7 @@ func (m queryMatcher) Match(r *http.Request, match *RouteMatch) bool {
 		if received == "" {
 			received = "(NONE)"
 		}
-		body := fmt.Sprint(
-			"Required Query Parameters Missing. \nReceived: ", received,
-			"\nMandatory Parameters: ", mapToString(m))
-		context.Set(r, MuxMatchErrorContextKey, MatchError{Code: 412, Body: body})
+		context.Set(r, MuxMatchErrorContextKey, MatchError{Code: 412})
 	}
 	return isMatch
 }
@@ -356,10 +350,7 @@ type schemeMatcher []string
 func (m schemeMatcher) Match(r *http.Request, match *RouteMatch) bool {
 	isMatch := matchInArray(m, r.URL.Scheme)
 	if !isMatch {
-		body := fmt.Sprint(
-			"Incorrect Protocol. \nReceived: ", r.URL.Scheme,
-			"\nExpected: ", strings.Join(m, ", "))
-		context.Set(r, MuxMatchErrorContextKey, MatchError{Code: 403, Body: body})
+		context.Set(r, MuxMatchErrorContextKey, MatchError{Code: 403})
 	}
 	return isMatch
 }

--- a/route.go
+++ b/route.go
@@ -181,11 +181,6 @@ type headerMatcher map[string]string
 func (m headerMatcher) Match(r *http.Request, match *RouteMatch) bool {
 	isMatch := matchMap(m, r.Header, true)
 	if !isMatch {
-		received := mapListToString(r.Header)
-		if received == "" {
-			received = "(NONE)"
-		}
-
 		context.Set(r, MuxMatchErrorContextKey, MatchError{Code: 412})
 	}
 	return isMatch
@@ -257,7 +252,7 @@ func (m methodMatcher) Match(r *http.Request, match *RouteMatch) bool {
 	isMatch := matchInArray(m, r.Method)
 	if !isMatch {
 		context.Set(r, MuxMatchErrorContextKey,
-			MatchError{Code: 405, Headers: http.Header{"Allow": m}})
+			MatchError{Code: 405, Header: http.Header{"Allow": m}})
 	}
 	return isMatch
 }
@@ -314,10 +309,6 @@ type queryMatcher map[string]string
 func (m queryMatcher) Match(r *http.Request, match *RouteMatch) bool {
 	isMatch := matchMap(m, r.URL.Query(), false)
 	if !isMatch {
-		received := mapListToString(r.URL.Query())
-		if received == "" {
-			received = "(NONE)"
-		}
 		context.Set(r, MuxMatchErrorContextKey, MatchError{Code: 412})
 	}
 	return isMatch


### PR DESCRIPTION
I opened bug #21, which was duplicate of #6 with more information.  This pull request implements _most_ of the suggestions from there.  I didn't get fancy with the header missing requests, so I just ended up using 412 regardless of the headers (some headers, per the protocol, should use different codes, it seems).

I have a good amount of tests in there, and a couple of helper methods.  I have implemented a new NotFound method handler (the default was the one from net/http, which is still used if my code doesn't find an error match).

I saw the response from @nesv about how it would take a lot of refactoring.  I kind of skirted around that by using the context to store error messages/codes that the default NotFound() handler looks for.  If those context variables aren't found, it defaults to the http.NotFound handler.  I thought this would be ok since this package is already tied to gorilla/context since it has the clearing of the context in ServeHTTP.

I hope this is accepted by the project.  I think this is a good way of handling custom errors, and it seems to fit in with being able to write your own matchers, as custom matchers aren't excluded from being able to set context.

If you notice that there is some code that shows up in the diff around clearing the context, it's because I have another pull request for optionally turning off context clearing.  However, I forgot to make a topic branch before I did the implementation for that _facepalm_.  I took that logic out of the code before I started this topic branch, and I double checked that the code from that pull request was taken out, but it still shows up in the diff.

Please let me know if there are any changes you want from me for this pull request.

Thanks!
