### PR TITLE
Add `Route.Or`

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -546,6 +546,50 @@ func TestSubRouter(t *testing.T) {
 	}
 }
 
+func TestAlternation(t *testing.T) {
+	contypeJson := new(Route).Headers("Content-Type", "application/json").
+		Or(new(Route).Headers("Content-Type", "text/json"))
+
+	appJsonReq := newRequest("GET", "www.google.com")
+	appJsonReq.Header.Add("Content-Type", "application/json")
+
+	txtJsonReq := newRequest("GET", "www.google.com")
+	txtJsonReq.Header.Add("Content-Type", "text/json")
+
+	plainReq := newRequest("GET", "www.google.com")
+
+	tests := []routeTest{
+		{
+			route:       contypeJson,
+			request:     appJsonReq,
+			vars:        map[string]string{},
+			host:        "",
+			path:        "",
+			shouldMatch: true,
+		},
+		{
+			route:       contypeJson,
+			request:     txtJsonReq,
+			vars:        map[string]string{},
+			host:        "",
+			path:        "",
+			shouldMatch: true,
+		},
+		{
+			route:       contypeJson,
+			request:     plainReq,
+			vars:        map[string]string{},
+			host:        "",
+			path:        "",
+			shouldMatch: false,
+		},
+	}
+
+	for _, test := range tests {
+		testRoute(t, test)
+	}
+}
+
 func TestNamedRoutes(t *testing.T) {
 	r1 := NewRouter()
 	r1.NewRoute().Name("a")


### PR DESCRIPTION
Unfortunately the `Queries` and `Headers` method work on an all or nothing basis (either EVERYTHING matches, or it's not a match).  This means that, especially for things like Content-Type headers, where you may want to allow flexible content-types, (for example: any one of the incorrect, but potentially used, json types listed in this question: http://stackoverflow.com/questions/477816/what-is-the-correct-json-content-type) there's no natural way to express 'Any one of these content types'.

I added an `Or` method to *Route that allows expression alternatives easily.  This could be useful for any of the scalar types as well (like Path or the like).

I'm not 100% pleased with how it turned out, as I dislike having to create an `AltRoute` method that creates a new route with the correct parent and other options, but doesn't get registered...it'd be nice if a Route could unregister iteself instead.  Despite that, it certainly fixes the problem.

I think the best, but unfortunately breaking, way to fix this problem would be to make a `matchInMap` that is orthogonal to `matchInArray` and it simply checks if any of the key-val combinations match at all.  You can already naturally express "and" in mux by adding a route matcher:

```
r.Headers("Content-Type", "application/json").Headers("X-Application-Name", "My-Application")
```

But you can't (easily) express an 'or' relationship except if the matchers themselves default to that behavior.
