### PR TITLE
Make PathPrefix more polite towards StrictSlash setting, and add better tests for the latter

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -119,9 +119,10 @@ func (r *Router) GetRoute(name string) *Route {
 // When false, if the route path is "/path", accessing "/path/" will not match
 // this route and vice versa.
 //
-// Special case: when a route sets a path prefix, strict slash is
-// automatically set to false for that route because the redirect behavior
-// can't be determined for prefixes.
+// Special case: when a route sets a path prefix using the PathPrefix() method,
+// strict slash is ignored for that route because the redirect behavior can't
+// be determined from a prefix alone. However, any subrouters created from that
+// route inherit the original StrictSlash setting.
 func (r *Router) StrictSlash(value bool) *Router {
 	r.strictSlash = value
 	return r

--- a/mux_test.go
+++ b/mux_test.go
@@ -661,6 +661,16 @@ func TestStrictSlash(t *testing.T) {
 			shouldRedirect: false,
 		},
 		{
+			title:          "Propagate StrictSlash to subrouters",
+			route:          r.NewRoute().PathPrefix("/static/").Subrouter().Path("/images/"),
+			request:        newRequest("GET", "http://localhost/static/images"),
+			vars:           map[string]string{},
+			host:           "",
+			path:           "/static/images/",
+			shouldMatch:    true,
+			shouldRedirect: true,
+		},
+		{
 			title:          "Ignore StrictSlash for path prefix",
 			route:          r.NewRoute().PathPrefix("/static/"),
 			request:        newRequest("GET", "http://localhost/static/logo.png"),

--- a/regexp.go
+++ b/regexp.go
@@ -98,12 +98,13 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, strictSlash bool) (*rout
 	}
 	// Done!
 	return &routeRegexp{
-		template:  template,
-		matchHost: matchHost,
-		regexp:    reg,
-		reverse:   reverse.String(),
-		varsN:     varsN,
-		varsR:     varsR,
+		template:    template,
+		matchHost:   matchHost,
+		strictSlash: strictSlash,
+		regexp:      reg,
+		reverse:     reverse.String(),
+		varsN:       varsN,
+		varsR:       varsR,
 	}, nil
 }
 
@@ -114,6 +115,8 @@ type routeRegexp struct {
 	template string
 	// True for host match, false for path match.
 	matchHost bool
+	// The strictSlash value defined on the route, but disabled if PathPrefix was used.
+	strictSlash bool
 	// Expanded regexp.
 	regexp *regexp.Regexp
 	// Reverse template.
@@ -216,7 +219,7 @@ func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) 
 				m.Vars[v] = pathVars[k+1]
 			}
 			// Check if we should redirect.
-			if r.strictSlash {
+			if v.path.strictSlash {
 				p1 := strings.HasSuffix(req.URL.Path, "/")
 				p2 := strings.HasSuffix(v.path.template, "/")
 				if p1 != p2 {

--- a/route.go
+++ b/route.go
@@ -294,7 +294,6 @@ func (r *Route) Path(tpl string) *Route {
 // Also note that the setting of Router.StrictSlash() has no effect on routes
 // with a PathPrefix matcher.
 func (r *Route) PathPrefix(tpl string) *Route {
-	r.strictSlash = false
 	r.err = r.addRegexpMatcher(tpl, false, true)
 	return r
 }


### PR DESCRIPTION
This is a partial fix for the problems mentioned in https://github.com/gorilla/mux/issues/31. It also documents the behaviour around slashes more thoroughly.
