### PR TITLE
BuildVarsFunc: modify route variables before building the URL from a route

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -146,6 +146,13 @@ func (r *Router) getRegexpGroup() *routeRegexpGroup {
 	return nil
 }
 
+func (r *Router) buildVars(m map[string]string) map[string]string {
+	if r.parent != nil {
+		m = r.parent.buildVars(m)
+	}
+	return m
+}
+
 // ----------------------------------------------------------------------------
 // Route factories
 // ----------------------------------------------------------------------------

--- a/mux.go
+++ b/mux.go
@@ -218,6 +218,12 @@ func (r *Router) Schemes(schemes ...string) *Route {
 	return r.NewRoute().Schemes(schemes...)
 }
 
+// BuildVars registers a new route with a custom function for modifying
+// route variables before building a URL.
+func (r *Router) BuildVarsFunc(f BuildVarsFunc) *Route {
+	return r.NewRoute().BuildVarsFunc(f)
+}
+
 // ----------------------------------------------------------------------------
 // Context
 // ----------------------------------------------------------------------------

--- a/mux_test.go
+++ b/mux_test.go
@@ -514,6 +514,7 @@ func TestMatcherFunc(t *testing.T) {
 func TestBuildVarsFunc(t *testing.T) {
 	tests := []routeTest{
 		{
+			title: "BuildVarsFunc set on route",
 			route: new(Route).Path(`/111/{v1:\d}{v2:.*}`).BuildVarsFunc(func(vars map[string]string) map[string]string {
 				vars["v1"] = "3"
 				vars["v2"] = "a"
@@ -521,6 +522,19 @@ func TestBuildVarsFunc(t *testing.T) {
 			}),
 			request:     newRequest("GET", "http://localhost/111/2"),
 			path:        "/111/3a",
+			shouldMatch: true,
+		},
+		{
+			title: "BuildVarsFunc set on route and parent route",
+			route: new(Route).PathPrefix(`/{v1:\d}`).BuildVarsFunc(func(vars map[string]string) map[string]string {
+				vars["v1"] = "2"
+				return vars
+			}).Subrouter().Path(`/{v2:\w}`).BuildVarsFunc(func(vars map[string]string) map[string]string {
+				vars["v2"] = "b"
+				return vars
+			}),
+			request:     newRequest("GET", "http://localhost/1/a"),
+			path:        "/2/b",
 			shouldMatch: true,
 		},
 	}

--- a/mux_test.go
+++ b/mux_test.go
@@ -511,6 +511,25 @@ func TestMatcherFunc(t *testing.T) {
 	}
 }
 
+func TestBuildVarsFunc(t *testing.T) {
+	tests := []routeTest{
+		{
+			route: new(Route).Path(`/111/{v1:\d}{v2:.*}`).BuildVarsFunc(func(vars map[string]string) map[string]string {
+				vars["v1"] = "3"
+				vars["v2"] = "a"
+				return vars
+			}),
+			request:     newRequest("GET", "http://localhost/111/2"),
+			path:        "/111/3a",
+			shouldMatch: true,
+		},
+	}
+
+	for _, test := range tests {
+		testRoute(t, test)
+	}
+}
+
 func TestSubRouter(t *testing.T) {
 	subrouter1 := new(Route).Host("{v1:[a-z]+}.google.com").Subrouter()
 	subrouter2 := new(Route).PathPrefix("/foo/{v1}").Subrouter()

--- a/regexp.go
+++ b/regexp.go
@@ -133,11 +133,7 @@ func (r *routeRegexp) Match(req *http.Request, match *RouteMatch) bool {
 }
 
 // url builds a URL part using the given values.
-func (r *routeRegexp) url(pairs ...string) (string, error) {
-	values, err := mapFromPairs(pairs...)
-	if err != nil {
-		return "", err
-	}
+func (r *routeRegexp) url(values map[string]string) (string, error) {
 	urlValues := make([]interface{}, len(r.varsN))
 	for k, v := range r.varsN {
 		value, ok := values[v]

--- a/route.go
+++ b/route.go
@@ -31,6 +31,8 @@ type Route struct {
 	name string
 	// Error resulted from building a route.
 	err error
+
+	buildVarsFunc BuildVarsFunc
 }
 
 // Match matches the route against the request.
@@ -336,6 +338,19 @@ func (r *Route) Schemes(schemes ...string) *Route {
 	return r.addMatcher(schemeMatcher(schemes))
 }
 
+// BuildVarsFunc --------------------------------------------------------------
+
+// BuildVarsFunc is the function signature used by custom build variable
+// functions (which can modify route variables before a route's URL is built).
+type BuildVarsFunc func(map[string]string) map[string]string
+
+// BuildVarsFunc adds a custom function to be used to modify build variables
+// before a route's URL is built.
+func (r *Route) BuildVarsFunc(f BuildVarsFunc) *Route {
+	r.buildVarsFunc = f
+	return r
+}
+
 // Subrouter ------------------------------------------------------------------
 
 // Subrouter creates a subrouter for the route.
@@ -398,17 +413,20 @@ func (r *Route) URL(pairs ...string) (*url.URL, error) {
 	if r.regexp == nil {
 		return nil, errors.New("mux: route doesn't have a host or path")
 	}
+	values, err := r.buildVars(pairs...)
+	if err != nil {
+		return nil, err
+	}
 	var scheme, host, path string
-	var err error
 	if r.regexp.host != nil {
 		// Set a default scheme.
 		scheme = "http"
-		if host, err = r.regexp.host.url(pairs...); err != nil {
+		if host, err = r.regexp.host.url(values); err != nil {
 			return nil, err
 		}
 	}
 	if r.regexp.path != nil {
-		if path, err = r.regexp.path.url(pairs...); err != nil {
+		if path, err = r.regexp.path.url(values); err != nil {
 			return nil, err
 		}
 	}
@@ -429,7 +447,11 @@ func (r *Route) URLHost(pairs ...string) (*url.URL, error) {
 	if r.regexp == nil || r.regexp.host == nil {
 		return nil, errors.New("mux: route doesn't have a host")
 	}
-	host, err := r.regexp.host.url(pairs...)
+	values, err := r.buildVars(pairs...)
+	if err != nil {
+		return nil, err
+	}
+	host, err := r.regexp.host.url(values)
 	if err != nil {
 		return nil, err
 	}
@@ -449,13 +471,30 @@ func (r *Route) URLPath(pairs ...string) (*url.URL, error) {
 	if r.regexp == nil || r.regexp.path == nil {
 		return nil, errors.New("mux: route doesn't have a path")
 	}
-	path, err := r.regexp.path.url(pairs...)
+	values, err := r.buildVars(pairs...)
+	if err != nil {
+		return nil, err
+	}
+	path, err := r.regexp.path.url(values)
 	if err != nil {
 		return nil, err
 	}
 	return &url.URL{
 		Path: path,
 	}, nil
+}
+
+// buildVars converts the route variable pairs into a map. If the route has a
+// BuildVarsFunc, it is invoked.
+func (r *Route) buildVars(pairs ...string) (map[string]string, error) {
+	m, err := mapFromPairs(pairs...)
+	if err != nil {
+		return nil, err
+	}
+	if r.buildVarsFunc != nil {
+		m = r.buildVarsFunc(m)
+	}
+	return m, nil
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This PR introduces a new BuildVarsFunc that can be attached to a route. A BuildVarsFunc allows you to intercept and modify the route variable map passed to `.URL` or `.URLPath` or `.URLHost` before generating the URL.

It is useful when you want to be liberal in matching routes but conservative in constructing them. For example, you might want to normalize all blog post URL slugs to be lowercase, but still match uppercase slugs. Without BuildVarsFunc, you would have to ensure that all callers of `.URL{,Path,Host}` lowercased the slug beforehand. With BuildVarsFunc, you can just call `.URL{,Path,Host}` directly without any additional wrapper functions.

BuildVarsFunc is useful in conjunction with PostMatchFunc at https://github.com/gorilla/mux/pull/53.