### PR TITLE
PostMatchFunc: modify route variables after a successful match

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -188,6 +188,12 @@ func (r *Router) MatcherFunc(f MatcherFunc) *Route {
 	return r.NewRoute().MatcherFunc(f)
 }
 
+// PostMatchFunc registers a new route with a custom post-match function. See
+// Route.PostMatchFunc().
+func (r *Router) PostMatchFunc(f PostMatchFunc) *Route {
+	return r.NewRoute().PostMatchFunc(f)
+}
+
 // Methods registers a new route with a matcher for HTTP methods.
 // See Route.Methods().
 func (r *Router) Methods(methods ...string) *Route {

--- a/mux_test.go
+++ b/mux_test.go
@@ -511,6 +511,24 @@ func TestMatcherFunc(t *testing.T) {
 	}
 }
 
+func TestPostMatchFunc(t *testing.T) {
+	tests := []routeTest{
+		{
+			route: new(Route).Path("/111/{v1:222}").PostMatchFunc(func(req *http.Request, match *RouteMatch, r *Route) {
+				match.Vars["v1p"] = "333"
+				delete(match.Vars, "v1")
+			}),
+			request:     newRequest("GET", "http://localhost/111/222"),
+			vars:        map[string]string{"v1p": "333"},
+			shouldMatch: true,
+		},
+	}
+
+	for _, test := range tests {
+		testRoute(t, test)
+	}
+}
+
 func TestSubRouter(t *testing.T) {
 	subrouter1 := new(Route).Host("{v1:[a-z]+}.google.com").Subrouter()
 	subrouter2 := new(Route).PathPrefix("/foo/{v1}").Subrouter()

--- a/route.go
+++ b/route.go
@@ -31,6 +31,8 @@ type Route struct {
 	name string
 	// Error resulted from building a route.
 	err error
+
+	postMatchFunc PostMatchFunc
 }
 
 // Match matches the route against the request.
@@ -57,6 +59,9 @@ func (r *Route) Match(req *http.Request, match *RouteMatch) bool {
 	// Set variables.
 	if r.regexp != nil {
 		r.regexp.setMatch(req, match, r)
+	}
+	if r.postMatchFunc != nil {
+		r.postMatchFunc(req, match, r)
 	}
 	return true
 }
@@ -235,6 +240,18 @@ func (m MatcherFunc) Match(r *http.Request, match *RouteMatch) bool {
 // MatcherFunc adds a custom function to be used as request matcher.
 func (r *Route) MatcherFunc(f MatcherFunc) *Route {
 	return r.addMatcher(f)
+}
+
+// PostMatchFunc --------------------------------------------------------------------
+
+// PostMatchFunc is the function signature used by custom var funcs.
+type PostMatchFunc func(req *http.Request, m *RouteMatch, r *Route)
+
+// PostMatchFunc sets a PostMatchFunc that will be called on a matched route to configure
+// the RouteMatch.
+func (r *Route) PostMatchFunc(f PostMatchFunc) *Route {
+	r.postMatchFunc = f
+	return r
 }
 
 // Methods --------------------------------------------------------------------


### PR DESCRIPTION
This PR introduces a new PostMatchFunc that can be attached to a route. A PostMatchFunc allows you to intercept and modify the route variable map after a successful match is made.

It is useful when you want to be liberal in matching routes but normalize matched route variables. For example, you might want to normalize all blog post URL slugs to be lowercase, but still match uppercase slugs. Without PostMatchFunc, you would have to ensure that all code that retrieves the matched route variables from `mux.Vars(r)` would perform the correct normalization on the correct variables. With PostMatchFunc, that normalization is performed automatically.

PostMatchFunc is useful in conjuction with BuildVarsFunc at https://github.com/gorilla/mux/pull/52.