### PR TITLE
Add SkipClean option

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -46,6 +46,8 @@ type Router struct {
 	namedRoutes map[string]*Route
 	// See Router.StrictSlash(). This defines the flag for new routes.
 	strictSlash bool
+	// See Router.SkipClean(). This defines the flag for new routes.
+	skipClean bool
 	// If true, do not clear the request context after handling the request
 	KeepContext bool
 }
@@ -65,19 +67,21 @@ func (r *Router) Match(req *http.Request, match *RouteMatch) bool {
 // When there is a match, the route variables can be retrieved calling
 // mux.Vars(request).
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	// Clean path to canonical form and redirect.
-	if p := cleanPath(req.URL.Path); p != req.URL.Path {
+	if !r.skipClean {
+		// Clean path to canonical form and redirect.
+		if p := cleanPath(req.URL.Path); p != req.URL.Path {
 
-		// Added 3 lines (Philip Schlump) - It was droping the query string and #whatever from query.
-		// This matches with fix in go 1.2 r.c. 4 for same problem.  Go Issue:
-		// http://code.google.com/p/go/issues/detail?id=5252
-		url := *req.URL
-		url.Path = p
-		p = url.String()
+			// Added 3 lines (Philip Schlump) - It was droping the query string and #whatever from query.
+			// This matches with fix in go 1.2 r.c. 4 for same problem.  Go Issue:
+			// http://code.google.com/p/go/issues/detail?id=5252
+			url := *req.URL
+			url.Path = p
+			p = url.String()
 
-		w.Header().Set("Location", p)
-		w.WriteHeader(http.StatusMovedPermanently)
-		return
+			w.Header().Set("Location", p)
+			w.WriteHeader(http.StatusMovedPermanently)
+			return
+		}
 	}
 	var match RouteMatch
 	var handler http.Handler
@@ -128,6 +132,19 @@ func (r *Router) StrictSlash(value bool) *Router {
 	return r
 }
 
+// SkipClean defines the path cleaning behaviour for new routes. The initial
+// value is false.
+//
+// When true, if the route path is "/path//to", it will remain with the double
+// slash. This is helpful if you have a route like: /fetch/http://xkcd.com/534/
+//
+// When false, the path will be cleaned, so /fetch/http://xkcd.com/534/ will
+// become /fetch/http/xkcd.com/534
+func (r *Router) SkipClean(value bool) *Router {
+	r.skipClean = value
+	return r
+}
+
 // ----------------------------------------------------------------------------
 // parentRoute
 // ----------------------------------------------------------------------------
@@ -158,7 +175,7 @@ func (r *Router) getRegexpGroup() *routeRegexpGroup {
 
 // NewRoute registers an empty route.
 func (r *Router) NewRoute() *Route {
-	route := &Route{parent: r, strictSlash: r.strictSlash}
+	route := &Route{parent: r, strictSlash: r.strictSlash, skipClean: r.skipClean}
 	r.routes = append(r.routes, route)
 	return route
 }
@@ -285,6 +302,7 @@ func cleanPath(p string) string {
 	if p[len(p)-1] == '/' && np != "/" {
 		np += "/"
 	}
+
 	return np
 }
 

--- a/route.go
+++ b/route.go
@@ -22,9 +22,12 @@ type Route struct {
 	matchers []matcher
 	// Manager for the variables from host and path.
 	regexp *routeRegexpGroup
-	// If true, when the path pattern is "/path/", accessing "/path" will
-	// redirect to the former and vice versa.
-	strictSlash bool
+    // If true, when the path pattern is "/path/", accessing "/path" will
+    // redirect to the former and vice versa.
+    strictSlash bool
+    // If true, when the path pattern is "/path//to", accessing "/path//to"
+    // will not redirect
+    skipClean bool
 	// If true, this route never matches: it is only used to build URLs.
 	buildOnly bool
 	// The name used to build URLs.


### PR DESCRIPTION
By default paths are run through the cleanPath method which prevents
using fancier paths like /fetch/http://xkcd.com/534

This adds a SkipClean option so that this path isn't redirected to
/fetch/http/xkcd.com/534
