### PR TITLE
X-HTTP-METHOD-OVERRIDE headers override method

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -398,15 +398,15 @@ func TestHeaders(t *testing.T) {
 			path:        "",
 			shouldMatch: false,
 		},
-    {
-      title:          "Accept X-HTTP-METHOD-OVERRIDE value as method",
-      route:          new(Route).Path("/867").Methods("PATCH"),
-      request:        newRequestHeaders("POST", "http://localhost/867", map[string]string{"X-HTTP-METHOD-OVERRIDE": "PATCH"}),
-      vars:           map[string]string{},
-      host:           "",
-      path:           "/867",
-      shouldMatch:    true,
-    },
+		{
+			title:       "Accept X-HTTP-METHOD-OVERRIDE value as method",
+			route:       new(Route).Path("/867").Methods("PATCH"),
+			request:     newRequestHeaders("POST", "http://localhost/867", map[string]string{"X-HTTP-METHOD-OVERRIDE": "PATCH"}),
+			vars:        map[string]string{},
+			host:        "",
+			path:        "/867",
+			shouldMatch: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/route.go
+++ b/route.go
@@ -263,11 +263,11 @@ func (r *Route) MatcherFunc(f MatcherFunc) *Route {
 type methodMatcher []string
 
 func (m methodMatcher) Match(r *http.Request, match *RouteMatch) bool {
-  override := r.Header["X-Http-Method-Override"]
-  if len(override) != 0 {
-    return matchInArray(m, strings.Join(override, ""))
-  }
-  return matchInArray(m, r.Method)
+	override := r.Header["X-Http-Method-Override"]
+	if len(override) != 0 {
+		return matchInArray(m, strings.Join(override, ""))
+	}
+	return matchInArray(m, r.Method)
 }
 
 // Methods adds a matcher for HTTP methods.


### PR DESCRIPTION
I could not find a standard for X-HTTP-METHOD-OVERRIDE. But, it is enabled with certain APIs, such as Google: https://developers.google.com/gdata/docs/2.0/basics
