### PR TITLE
Add panic handler.

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -38,6 +38,8 @@ func NewRouter() *Router {
 type Router struct {
 	// Configurable Handler to be used when no route matches.
 	NotFoundHandler http.Handler
+	// Configurable Handler to be used for panic handling.
+	PanicHandler http.Handler
 	// Parent route, if this is a subrouter.
 	parent parentRoute
 	// Routes to be matched, in order.
@@ -94,6 +96,9 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	if !r.KeepContext {
 		defer context.Clear(req)
+	}
+	if r.PanicHandler != nil {
+		defer r.PanicHandler.ServeHTTP(w, req)
 	}
 	handler.ServeHTTP(w, req)
 }


### PR DESCRIPTION
Hello. This pull request adds basic ability to handle panics in handlers:

``` go
type panicHandler struct{}

func (*panicHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
    p := recover()
    if p != nil {
        rw.WriteHeader(500)
        log.Print(p)
        // something else
    }
}

func main() {
    r := mux.NewRouter()
    r.PanicHandler = new(panicHandler)
}
```

I think that this style of panic handling is as useful as 404 handler, and definitely is an improvement over default `http` package behavior. 

The obvious gotcha with this approach that one can't use function and `HandlerFunc` instead of type implementing `http. Handler` for not-so-obvious reason.

Another approach is to define custom type like:

``` go
type PanicHandler interface {
        ServeHTTP(rw ResponseWriter, req *Request, p interface{})
}
```

I'm open for discussion.
