### PR TITLE
Add opt-in HTTPMethodOverride functionality (ported from gorilla/handlers)

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -46,6 +46,8 @@ type Router struct {
 	namedRoutes map[string]*Route
 	// See Router.StrictSlash(). This defines the flag for new routes.
 	strictSlash bool
+	// See Router.HTTPMethodOverride(). This defines the flag for new routes.
+	httpMethodOverride bool
 	// If true, do not clear the request context after handling the request
 	KeepContext bool
 }
@@ -128,6 +130,25 @@ func (r *Router) StrictSlash(value bool) *Router {
 	return r
 }
 
+// HTTPMethodOverride defines the HTTP Method overriding behaviour for new
+// routes. The initial value is false.
+//
+// When true, if the request contains the Header "X-HTTP-Method-Override", or
+// the form key "_method", then request.Method will be updated with its value.
+// Form key "_method" takes precedence over Header "X-HTTP-Method-Override".
+//
+// When false, no checks against the header or form keys will be performed, and
+// no method overridding will occur.
+//
+// This is especially useful for http clients that don't support many http
+// verbs. It isn't secure to override e.g a GET to a POST, so only POST
+// requests are considered. Likewise, the override method can only be a "write"
+// method: PUT, PATCH or DELETE.
+func (r *Router) HTTPMethodOverride(value bool) *Router {
+	r.httpMethodOverride = value
+	return r
+}
+
 // ----------------------------------------------------------------------------
 // parentRoute
 // ----------------------------------------------------------------------------
@@ -158,7 +179,7 @@ func (r *Router) getRegexpGroup() *routeRegexpGroup {
 
 // NewRoute registers an empty route.
 func (r *Router) NewRoute() *Route {
-	route := &Route{parent: r, strictSlash: r.strictSlash}
+	route := &Route{parent: r, strictSlash: r.strictSlash, httpMethodOverride: r.httpMethodOverride}
 	r.routes = append(r.routes, route)
 	return route
 }

--- a/old_test.go
+++ b/old_test.go
@@ -286,22 +286,22 @@ type methodMatcherTest struct {
 
 var methodMatcherTests = []methodMatcherTest{
 	{
-		matcher: methodMatcher([]string{"GET", "POST", "PUT"}),
+		matcher: methodMatcher{[]string{"GET", "POST", "PUT"}, false},
 		method:  "GET",
 		result:  true,
 	},
 	{
-		matcher: methodMatcher([]string{"GET", "POST", "PUT"}),
+		matcher: methodMatcher{[]string{"GET", "POST", "PUT"}, false},
 		method:  "POST",
 		result:  true,
 	},
 	{
-		matcher: methodMatcher([]string{"GET", "POST", "PUT"}),
+		matcher: methodMatcher{[]string{"GET", "POST", "PUT"}, false},
 		method:  "PUT",
 		result:  true,
 	},
 	{
-		matcher: methodMatcher([]string{"GET", "POST", "PUT"}),
+		matcher: methodMatcher{[]string{"GET", "POST", "PUT"}, false},
 		method:  "DELETE",
 		result:  false,
 	},


### PR DESCRIPTION
[I know you've had previous discussions on this topic](https://github.com/gorilla/mux/pull/57), but if you ***are*** interested (fair enough you might not be) in adding this functionality to gorilla/mux then this pull request implements HTTPMethodOverride (ported from gorilla/handlers) as a Router method in mux. It's completely opt-in so doesn't affect any existing code. The API is modelled after StrictSlash(), as a method on Router that defaults to false.

It adds: -

1. A new method, `*Router.HTTPMethodOverride(bool)`

2. When set to `true`, it checks POST requests for the `X-HTTP-Method-Override` header and/or the form key `_method`, if either are found (and the value matches one of `PUT`, `PATCH`, or `DELETE`) then `request.Method` is updated with that value. GET requests are not checked, neither are any other method values valid. (Same approach as gorilla/handlers)

3. When set to `false` (the default), behaviour is exactly the same as current gorilla/mux

4. New Test, `TestHTTPMethodOverride()` covers all the new functionality

5. Full documentation (matching existing gorilla/mux style)

(I also updated `old_test.go`)

Obviously it's totally up to you guys as to whether you think this functionality should be included in mux - but it's there if you want it. Speaking personally I added it since, as a newcomer to Go, I was surprised/confused that when I tried to use `.Methods("PUT")` and then `<input type="hidden" name="_method" value="put" />` in my HTML `form` it didn't work as expected, especially since standard browsers don't currently implement the PUT/PATCH/DELETE HTTP verbs. Implementing it as a purely opt-in feature was I thought the best strategy since it doesn't affect existing use of the library. Anyway, if you do feel it's a worthy/relevant addition to mux then you can merge it. If not, no worries. (and feel free to delete this PR). Thanks.
