### PR TITLE
Add router wide middleware using justinas/alice

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -6,10 +6,10 @@ package mux
 
 import (
 	"fmt"
+	"github.com/gorilla/context"
+	"github.com/justinas/alice"
 	"net/http"
 	"path"
-
-	"github.com/gorilla/context"
 )
 
 // NewRouter returns a new router instance.
@@ -48,6 +48,8 @@ type Router struct {
 	strictSlash bool
 	// If true, do not clear the request context after handling the request
 	KeepContext bool
+	// A router wide middleware chain
+	Chain alice.Chain
 }
 
 // Match matches registered routes against the request.
@@ -95,7 +97,9 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if !r.KeepContext {
 		defer context.Clear(req)
 	}
-	handler.ServeHTTP(w, req)
+
+	// Serve the route with our global chain
+	r.Chain.Then(handler).ServeHTTP(w, req)
 }
 
 // Get returns a route registered with the given name.


### PR DESCRIPTION
This adds support for a router wide chain(list of middleware handlers) using [alice](https://github.com/justinas/alice).

Currently it's very easy to use alice to have middleware with any router on a per route level but you can't have a router wide chain without repeating yourself everywhere. If you want to learn more about alice I suggest you read the creators [blog post](http://justinas.org/alice-painless-middleware-chaining-for-go/) for a good explaination of how it works.
