### PR TITLE
Implement Router.Walk

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -5,6 +5,7 @@
 package mux
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"path"
@@ -235,6 +236,40 @@ func (r *Router) Schemes(schemes ...string) *Route {
 // route variables before building a URL.
 func (r *Router) BuildVarsFunc(f BuildVarsFunc) *Route {
 	return r.NewRoute().BuildVarsFunc(f)
+}
+
+// Walk walks the router and all its sub-routers, calling walkFn for each route
+// in the tree. The routes are walked in the order they were added. Sub-routers
+// are explored depth-first.
+func (r *Router) Walk(walkFn WalkFunc) error {
+	return r.walk(walkFn, []*Route{})
+}
+
+// SkipRouter is used as a return value from WalkFuncs to indicate that the
+// router that walk is about to descend down to should be skipped.
+var SkipRouter = errors.New("skip this router")
+
+// WalkFunc is the type of the function called for each route visited by Walk.
+// At every invocation, it is given the current route, and the current router,
+// and a list of ancestor routes that lead to the current route.
+type WalkFunc func(route *Route, router *Router, ancestors []*Route) error
+
+func (r *Router) walk(walkFn WalkFunc, ancestors []*Route) error {
+	for _, t := range r.routes {
+		err := walkFn(t, r, ancestors)
+		if err == SkipRouter {
+			continue
+		}
+		if h, ok := t.handler.(*Router); ok {
+			ancestors = append(ancestors, t)
+			err := h.walk(walkFn, ancestors)
+			if err != nil {
+				return err
+			}
+			ancestors = ancestors[:len(ancestors)-1]
+		}
+	}
+	return nil
 }
 
 // ----------------------------------------------------------------------------

--- a/mux_test.go
+++ b/mux_test.go
@@ -765,6 +765,51 @@ func TestStrictSlash(t *testing.T) {
 	}
 }
 
+func TestWalk(t *testing.T) {
+	r0 := NewRouter()
+	r1 := NewRouter()
+	r2 := NewRouter()
+
+	r0.Path("/g")
+	r0.Path("/o")
+	r0.Path("/d").Handler(r1)
+	r0.Path("/r").Handler(r2)
+	r0.Path("/a")
+
+	r1.Path("/z")
+	r1.Path("/i")
+	r1.Path("/l")
+	r1.Path("/l")
+
+	r2.Path("/i")
+	r2.Path("/l")
+	r2.Path("/l")
+
+	paths := []string{"g", "o", "r", "i", "l", "l", "a"}
+	depths := []int{0, 0, 0, 1, 1, 1, 0}
+	i := 0
+	err := r0.Walk(func(route *Route, router *Router, ancestors []*Route) error {
+		matcher := route.matchers[0].(*routeRegexp)
+		if matcher.template == "/d" {
+			return SkipRouter
+		}
+		if len(ancestors) != depths[i] {
+			t.Errorf(`Expected depth of %d at i = %d; got "%s"`, depths[i], i, len(ancestors))
+		}
+		if matcher.template != "/"+paths[i] {
+			t.Errorf(`Expected "/%s" at i = %d; got "%s"`, paths[i], i, matcher.template)
+		}
+		i++
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	if i != len(paths) {
+		t.Errorf("Expected %d routes, found %d", len(paths), i)
+	}
+}
+
 // ----------------------------------------------------------------------------
 // Helpers
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces the Walk() method we were talking about in Google Groups.. 

The function takes an "iteratee" that satisfies the WalkFunc type. The WalkFunc type is a function that takes a single argument: a Route pointer.

The iteratee is invoked once for every route. However, if it encounters a route that actually holds a sub-router, it recursively calls the Walk() method of the sub-router with the same iteratee. The routes that are handled by a router are always walked in order of insertion (in other words, we just loop over the routes array). Upon encountering a sub-router, it dives in - depth-first. Worth mentioning, the route that actually holds the sub-router is not passed to walkFn. We can still tweak the logic to include it, but it isn't really a "true" route, is it?

The behavior of this method is similar to that of `filepath.Walk`, only simpler. Since `filepath.Walk` attempts to sort the paths of the current directory by name before looping over them. Since not all routes are named in Gorilla, there is nothing really to sort on, and maintaining the order of insertion made more sense.

A test has been added that checks if the order is maintained, and also if the number of routes "walked" on is correct.