### PR TITLE
Fix up doc formatting, use spaces for alignment (tabs are for indentation only).

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -89,7 +89,7 @@ There are several other matchers that can be added. To match path prefixes:
 
 	r.MatcherFunc(func(r *http.Request, rm *RouteMatch) bool {
 		return r.ProtoMajor == 0
-    })
+	})
 
 ...and finally, it is possible to combine several matchers in a single route:
 
@@ -164,8 +164,8 @@ This also works for host variables:
 
 	// url.String() will be "http://news.domain.com/articles/technology/42"
 	url, err := r.Get("article").URL("subdomain", "news",
-									 "category", "technology",
-									 "id", "42")
+	                                 "category", "technology",
+	                                 "id", "42")
 
 All variables defined in the route are required, and their values must
 conform to the corresponding patterns. These requirements guarantee that a
@@ -193,7 +193,7 @@ as well:
 
 	// "http://news.domain.com/articles/technology/42"
 	url, err := r.Get("article").URL("subdomain", "news",
-									 "category", "technology",
-									 "id", "42")
+	                                 "category", "technology",
+	                                 "id", "42")
 */
 package mux


### PR DESCRIPTION
This fixes issue where if user has tab width other than 4, some lines will become misaligned. For example, see the package description at https://godoc.org/github.com/gorilla/mux.

![image](https://cloud.githubusercontent.com/assets/1924134/7283436/67547294-e8eb-11e4-994e-02dfae4c00c7.png)