### PR TITLE
Fixing query regexp patterns with quantifiers 

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -552,6 +552,24 @@ func TestQueries(t *testing.T) {
 			path:        "",
 			shouldMatch: false,
 		},
+		{
+			title:       "Queries route with regexp pattern with quantifier, match",
+			route:       new(Route).Queries("foo", "{v1:[0-9]{1}}"),
+			request:     newRequest("GET", "http://localhost?foo=1"),
+			vars:        map[string]string{"v1": "1"},
+			host:        "",
+			path:        "",
+			shouldMatch: true,
+		},
+		{
+			title:       "Queries route with regexp pattern with quantifier, regexp does not match",
+			route:       new(Route).Queries("foo", "{v1:[0-9]{1}}"),
+			request:     newRequest("GET", "http://localhost?foo=12"),
+			vars:        map[string]string{},
+			host:        "",
+			path:        "",
+			shouldMatch: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/regexp.go
+++ b/regexp.go
@@ -35,7 +35,6 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash 
 	defaultPattern := "[^/]+"
 	if matchQuery {
 		defaultPattern = "[^?&]+"
-		matchPrefix = true
 	} else if matchHost {
 		defaultPattern = "[^.]+"
 		matchPrefix = false
@@ -53,9 +52,7 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash 
 	varsN := make([]string, len(idxs)/2)
 	varsR := make([]*regexp.Regexp, len(idxs)/2)
 	pattern := bytes.NewBufferString("")
-	if !matchQuery {
-		pattern.WriteByte('^')
-	}
+	pattern.WriteByte('^')
 	reverse := bytes.NewBufferString("")
 	var end int
 	var err error
@@ -78,6 +75,7 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash 
 		fmt.Fprintf(pattern, "%s(%s)", regexp.QuoteMeta(raw), patt)
 		// Build the reverse template.
 		fmt.Fprintf(reverse, "%s%%s", raw)
+
 		// Append variable name and compiled pattern.
 		varsN[i/2] = name
 		varsR[i/2], err = regexp.Compile(fmt.Sprintf("^%s$", patt))
@@ -141,7 +139,7 @@ type routeRegexp struct {
 func (r *routeRegexp) Match(req *http.Request, match *RouteMatch) bool {
 	if !r.matchHost {
 		if r.matchQuery {
-			return r.regexp.MatchString(req.URL.RawQuery)
+			return r.regexp.MatchString(r.getUrlQuery(req))
 		} else {
 			return r.regexp.MatchString(req.URL.Path)
 		}
@@ -173,6 +171,18 @@ func (r *routeRegexp) url(values map[string]string) (string, error) {
 		}
 	}
 	return rv, nil
+}
+
+// getUrlQuery returns a single query parameter from a request URL.
+// For a URL with foo=bar&baz=ding, we return only the relevant key
+// value pair for the routeRegexp.
+func (r *routeRegexp) getUrlQuery(req *http.Request) string {
+	keyVal := strings.Split(r.template, "=")
+	if len(keyVal) == 0 {
+		return ""
+	}
+	re := regexp.MustCompile(keyVal[0] + "[^&]*")
+	return re.FindString(req.URL.RawQuery)
 }
 
 // braceIndices returns the first level curly brace indices from a string.
@@ -246,9 +256,8 @@ func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) 
 		}
 	}
 	// Store query string variables.
-	rawQuery := req.URL.RawQuery
 	for _, q := range v.queries {
-		queryVars := q.regexp.FindStringSubmatch(rawQuery)
+		queryVars := q.regexp.FindStringSubmatch(q.getUrlQuery(req))
 		if queryVars != nil {
 			for k, v := range q.varsN {
 				m.Vars[v] = queryVars[k+1]

--- a/regexp.go
+++ b/regexp.go
@@ -139,7 +139,7 @@ type routeRegexp struct {
 func (r *routeRegexp) Match(req *http.Request, match *RouteMatch) bool {
 	if !r.matchHost {
 		if r.matchQuery {
-			return r.regexp.MatchString(r.getUrlQuery(req))
+			return r.matchQueryString(req)
 		} else {
 			return r.regexp.MatchString(req.URL.Path)
 		}
@@ -177,12 +177,16 @@ func (r *routeRegexp) url(values map[string]string) (string, error) {
 // For a URL with foo=bar&baz=ding, we return only the relevant key
 // value pair for the routeRegexp.
 func (r *routeRegexp) getUrlQuery(req *http.Request) string {
-	keyVal := strings.Split(r.template, "=")
-	if len(keyVal) == 0 {
+	if !r.matchQuery {
 		return ""
 	}
-	re := regexp.MustCompile(keyVal[0] + "[^&]*")
-	return re.FindString(req.URL.RawQuery)
+	key := strings.Split(r.template, "=")[0]
+	val := req.URL.Query().Get(key)
+	return key + "=" + val
+}
+
+func (r *routeRegexp) matchQueryString(req *http.Request) bool {
+	return r.regexp.MatchString(r.getUrlQuery(req))
 }
 
 // braceIndices returns the first level curly brace indices from a string.

--- a/route.go
+++ b/route.go
@@ -336,7 +336,7 @@ func (r *Route) Queries(pairs ...string) *Route {
 		return nil
 	}
 	for i := 0; i < length; i += 2 {
-		if r.err = r.addRegexpMatcher(pairs[i]+"="+pairs[i+1], false, true, true); r.err != nil {
+		if r.err = r.addRegexpMatcher(pairs[i]+"="+pairs[i+1], false, false, true); r.err != nil {
 			return r
 		}
 	}


### PR DESCRIPTION
PR adds support for regexp quantifiers for query strings, so that ```Queries("foo", "{v1:[a-z]{3}}")``` will match for ```&foo=bar``` but not for ```&foo=bars```.

The query matcher currently looks for ```foo=[a-z]{3}``` in the entire URL query string (```baz=ding&foo=bars```) and returns a match. PR looks for ```^foo=[a-z]{3}$``` in only ```foo=bars``` and therefore will not match.
