### PR TITLE
Add two helper methods

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -283,6 +283,16 @@ func setCurrentRoute(r *http.Request, val interface{}) {
 // Helpers
 // ----------------------------------------------------------------------------
 
+func NamedMatch(name string, match string) string {
+    return fmt.Sprintf("{%s:%s}", name, match)
+}
+
+func CreatePath(parts ...string) string {
+    url := path.Join(parts...)
+    url = cleanPath("/" + url)
+    return url
+}
+
 // cleanPath returns the canonical path for p, eliminating . and .. elements.
 // Borrowed from the net/http package.
 func cleanPath(p string) string {

--- a/mux_test.go
+++ b/mux_test.go
@@ -1046,3 +1046,44 @@ func newRequest(method, url string) *http.Request {
 	}
 	return req
 }
+
+func TestNamedMatch(t *testing.T) {
+    for _, test := range named_match_tests {
+    	result := NamedMatch(test.name, test.match)
+    	if result != test.expected {
+    		t.Errorf("Expecting %s, got %s", test.expected, result)
+    	}
+    }
+}
+
+var named_match_tests = []struct {
+    name string
+    match string
+    expected string
+} {
+    {"item1", "[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}", "{item1:[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}}"},
+    {"item2", "[a-z0-9-_~.]+", "{item2:[a-z0-9-_~.]+}"},
+}
+
+func TestCreatePath(t *testing.T) {
+    for _, test := range create_path_tests {
+    	result := CreatePath(test.parts...)
+    	if result != test.expected {
+    		t.Errorf("Expecting %s, got %s", test.expected, result)
+    	}
+    }
+}
+
+var create_path_tests = []struct {
+    parts []string
+    expected string
+} {
+    {
+    	[]string{"g", "o", "r", "i", "l", "l", "a"},
+    	"/g/o/r/i/l/l/a",
+    },
+    {
+    	[]string{"section", NamedMatch("id", "[0-9]+")},
+    	"/section/{id:[0-9]+}",
+    },
+}


### PR DESCRIPTION
I added NamedMatch & CreatePath as I find these two methods helpful when doing stuff like

```
var uuid_match = "[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}"
var name_match = "[a-z0-9-_~.]+"

r := mux.NewRouter()
r.HanderFunc(
    CreatePath("section", NamedMatch("id", uuid_match), "something"),
    TestById
)
r.HanderFunc(
    CreatePath("section", NamedMatch("name", name_match), "something"),
    TestByName
)
r.HanderFunc(
    CreatePath("section1", NamedMatch("id", uuid_match), "something"),
    Test1ById
)
r.HanderFunc(
    CreatePath("section1", NamedMatch("name", name_match), "something"),
    Test1ByName
)
```

If you feel these should not be in the API thats fine, just close this PR