### PR TITLE
fix for empty query

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -588,6 +588,15 @@ func TestQueries(t *testing.T) {
 			path:        "",
 			shouldMatch: false,
 		},
+		{
+			title:       "Queries route with empty value, should match",
+			route:       new(Route).Queries("foo", ""),
+			request:     newRequest("GET", "http://localhost?foo=bar"),
+			vars:        map[string]string{},
+			host:        "",
+			path:        "",
+			shouldMatch: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/mux_test.go
+++ b/mux_test.go
@@ -597,6 +597,15 @@ func TestQueries(t *testing.T) {
 			path:        "",
 			shouldMatch: true,
 		},
+		{
+			title:       "Queries route with overlapping value, should not match",
+			route:       new(Route).Queries("foo", "bar"),
+			request:     newRequest("GET", "http://localhost?foo=barfoo"),
+			vars:        map[string]string{},
+			host:        "",
+			path:        "",
+			shouldMatch: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/regexp.go
+++ b/regexp.go
@@ -89,8 +89,11 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash 
 	if strictSlash {
 		pattern.WriteString("[/]?")
 	}
-	if matchQuery && len(idxs) == 0 {
-		pattern.WriteString(defaultPattern)
+	if matchQuery {
+		// Add the default pattern if the query value is empty
+		if queryVal := strings.SplitN(template, "=", 2)[1]; queryVal == "" {
+			pattern.WriteString(defaultPattern)
+		}
 	}
 	if !matchPrefix {
 		pattern.WriteByte('$')

--- a/regexp.go
+++ b/regexp.go
@@ -34,7 +34,7 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash 
 	// Now let's parse it.
 	defaultPattern := "[^/]+"
 	if matchQuery {
-		defaultPattern = "[^?&]+"
+		defaultPattern = "[^?&]*"
 	} else if matchHost {
 		defaultPattern = "[^.]+"
 		matchPrefix = false
@@ -88,6 +88,9 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash 
 	pattern.WriteString(regexp.QuoteMeta(raw))
 	if strictSlash {
 		pattern.WriteString("[/]?")
+	}
+	if matchQuery && len(idxs) == 0 {
+		pattern.WriteString(defaultPattern)
 	}
 	if !matchPrefix {
 		pattern.WriteByte('$')


### PR DESCRIPTION
This PR is a solution to the issue raised by @epelc in https://github.com/gorilla/mux/commit/0c9d5c08c1d6103f2ced11750a195fc94902d3fc#commitcomment-12196652

Not sure if it's the right approach but at least something for discussion. There should be a more idiomatic/explicit way to test if the ```defaultPattern``` should be added to the ```pattern``` but this was an easy way to do it.