### PR TITLE
Issue #109

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -598,6 +598,24 @@ func TestQueries(t *testing.T) {
 			shouldMatch: true,
 		},
 		{
+			title:       "Queries route with empty value and no parameter in request, should not match",
+			route:       new(Route).Queries("foo", ""),
+			request:     newRequest("GET", "http://localhost"),
+			vars:        map[string]string{},
+			host:        "",
+			path:        "",
+			shouldMatch: false,
+		},
+		{
+			title:       "Queries route with empty value and empty parameter in request, should match",
+			route:       new(Route).Queries("foo", ""),
+			request:     newRequest("GET", "http://localhost?foo="),
+			vars:        map[string]string{},
+			host:        "",
+			path:        "",
+			shouldMatch: true,
+		},
+		{
 			title:       "Queries route with overlapping value, should not match",
 			route:       new(Route).Queries("foo", "bar"),
 			request:     newRequest("GET", "http://localhost?foo=barfoo"),
@@ -607,13 +625,22 @@ func TestQueries(t *testing.T) {
 			shouldMatch: false,
 		},
 		{
-			title:       "Queries route with no parameter in request , should not match",
+			title:       "Queries route with no parameter in request, should not match",
 			route:       new(Route).Queries("foo", "{bar}"),
 			request:     newRequest("GET", "http://localhost"),
 			vars:        map[string]string{},
 			host:        "",
 			path:        "",
 			shouldMatch: false,
+		},
+		{
+			title:       "Queries route with empty parameter in request, should match",
+			route:       new(Route).Queries("foo", "{bar}"),
+			request:     newRequest("GET", "http://localhost?foo="),
+			vars:        map[string]string{"foo": ""},
+			host:        "",
+			path:        "",
+			shouldMatch: true,
 		},
 	}
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -606,6 +606,15 @@ func TestQueries(t *testing.T) {
 			path:        "",
 			shouldMatch: false,
 		},
+		{
+			title:       "Queries route with no parameter in request , should not match",
+			route:       new(Route).Queries("foo", "{bar}"),
+			request:     newRequest("GET", "http://localhost"),
+			vars:        map[string]string{},
+			host:        "",
+			path:        "",
+			shouldMatch: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/regexp.go
+++ b/regexp.go
@@ -186,9 +186,13 @@ func (r *routeRegexp) getUrlQuery(req *http.Request) string {
 	if !r.matchQuery {
 		return ""
 	}
-	key := strings.Split(r.template, "=")[0]
-	val := req.URL.Query().Get(key)
-	return key + "=" + val
+	templateKey := strings.Split(r.template, "=")[0]
+	for key, vals := range req.URL.Query() {
+		if key == templateKey && len(vals) > 0 {
+			return key + "=" + vals[0]
+		}
+	}
+	return ""
 }
 
 func (r *routeRegexp) matchQueryString(req *http.Request) bool {


### PR DESCRIPTION
Fix for https://github.com/gorilla/mux/issues/109.

Unfortunately we broke the query matcher when the query's ```defaultPattern``` was changed in https://github.com/gorilla/mux/pull/108.

In this PR the ```getUrlQuery``` method loops over query parameters and only returns a string to match if the the parameter exists in the request (which is how it should have been in the first place).