### PR TITLE
Add note about the availability of CurrentRoute.

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -312,9 +312,10 @@ func Vars(r *http.Request) map[string]string {
 }
 
 // CurrentRoute returns the matched route for the current request, if any.
-// Note: this only works when called inside the handler of the matched route
-// because it uses context.Get() which will be cleared after executing the
-// handler.
+// This only works when called inside the handler of the matched route
+// because the matched route is stored in the request context which is cleared
+// after the handler returns, unless the KeepContext option is set on the
+// Router.
 func CurrentRoute(r *http.Request) *Route {
 	if rv := context.Get(r, routeKey); rv != nil {
 		return rv.(*Route)

--- a/mux.go
+++ b/mux.go
@@ -312,6 +312,9 @@ func Vars(r *http.Request) map[string]string {
 }
 
 // CurrentRoute returns the matched route for the current request, if any.
+// Note: this only works when called inside the handler of the matched route
+// because it uses context.Get() which will be cleared after executing the
+// handler.
 func CurrentRoute(r *http.Request) *Route {
 	if rv := context.Get(r, routeKey); rv != nil {
 		return rv.(*Route)


### PR DESCRIPTION
For a middleware I'm working on I wanted to use ``CurrentRoute`` and was surprised it always returned ``nil``. Then I realised it is only set just before the handler will be called and will be cleared directly after (on purpose) here: https://github.com/gorilla/mux/blob/master/mux.go#L98

I think it would be a good idea to add a small note, to take the expectation away that ``CurrentRoute`` can be used outside the handler.