### PR TITLE
Updated README w/ runnable example. Addresses #32.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,34 @@ as well:
 	url, err := r.Get("article").URL("subdomain", "news",
 	                                 "category", "technology",
 	                                 "id", "42")
+
+## Full Example
+
+Here's a complete, runnable example of a small mux based server:
+
+```go
+package main
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func YourHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("Gorilla!\n"))
+}
+
+func main() {
+	r := mux.NewRouter()
+	// Routes consist of a path and a handler function.
+	r.HandleFunc("/", YourHandler)
+
+	// Bind to a port and pass our router in
+	http.ListenAndServe(":8000", r)
+}
+```
+
+## License
+
+BSD licensed. See the LICENSE file for details.


### PR DESCRIPTION
Added a (small) complete example to the README that includes how to pass a router to `http.ListenAndServe` for newbie Gophers.

Addresses https://github.com/gorilla/mux/issues/32