### PR TITLE
HeadersRegexp stores regexp captures in mux's Vars

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -537,6 +537,24 @@ func TestHeaders(t *testing.T) {
 			path:        "",
 			shouldMatch: true,
 		},
+		{
+			title:       "Headers route, regex header values to match with captured vars",
+			route:       new(Route).HeadersRegexp("foo", "{v1:ba[zr]}"),
+			request:     newRequestHeaders("GET", "http://localhost", map[string]string{"foo": "baz"}),
+			vars:        map[string]string{"v1": "baz"},
+			host:        "",
+			path:        "",
+			shouldMatch: true,
+		},
+		{
+			title:       "Headers route, regex header values to match with several captured vars",
+			route:       new(Route).HeadersRegexp("foo", "{v1:ba[zr]}", "qux", "{v2:n.+f}"),
+			request:     newRequestHeaders("GET", "http://localhost", map[string]string{"foo": "baz", "qux": "norf"}),
+			vars:        map[string]string{"v1": "baz", "v2": "norf"},
+			host:        "",
+			path:        "",
+			shouldMatch: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/old_test.go
+++ b/old_test.go
@@ -691,7 +691,7 @@ func TestNewRegexp(t *testing.T) {
 	}
 
 	for pattern, paths := range tests {
-		p, _ = newRouteRegexp(pattern, false, false, false, false)
+		p, _ = newRouteRegexp(pattern, false, false, false, false, false)
 		for path, result := range paths {
 			matches = p.regexp.FindStringSubmatch(path)
 			if result == nil {

--- a/route.go
+++ b/route.go
@@ -138,12 +138,12 @@ func (r *Route) addMatcher(m matcher) *Route {
 }
 
 // addRegexpMatcher adds a host or path matcher and builder to a route.
-func (r *Route) addRegexpMatcher(tpl string, matchHost, matchPrefix, matchQuery bool) error {
+func (r *Route) addRegexpMatcher(tpl string, matchHost, matchPrefix, matchQuery bool, matchHeader bool) error {
 	if r.err != nil {
 		return r.err
 	}
 	r.regexp = r.getRegexpGroup()
-	if !matchHost && !matchQuery {
+	if !matchHost && !matchQuery && !matchHeader {
 		if len(tpl) == 0 || tpl[0] != '/' {
 			return fmt.Errorf("mux: path must start with a slash, got %q", tpl)
 		}
@@ -151,11 +151,16 @@ func (r *Route) addRegexpMatcher(tpl string, matchHost, matchPrefix, matchQuery 
 			tpl = strings.TrimRight(r.regexp.path.template, "/") + tpl
 		}
 	}
-	rr, err := newRouteRegexp(tpl, matchHost, matchPrefix, matchQuery, r.strictSlash)
+	rr, err := newRouteRegexp(tpl, matchHost, matchPrefix, matchQuery, matchHeader, r.strictSlash)
 	if err != nil {
 		return err
 	}
 	for _, q := range r.regexp.queries {
+		if err = uniqueVars(rr.varsN, q.varsN); err != nil {
+			return err
+		}
+	}
+	for _, q := range r.regexp.headers {
 		if err = uniqueVars(rr.varsN, q.varsN); err != nil {
 			return err
 		}
@@ -175,9 +180,12 @@ func (r *Route) addRegexpMatcher(tpl string, matchHost, matchPrefix, matchQuery 
 		}
 		if matchQuery {
 			r.regexp.queries = append(r.regexp.queries, rr)
-		} else {
+		} else if !matchHeader {
 			r.regexp.path = rr
 		}
+	}
+	if matchHeader {
+		r.regexp.headers = append(r.regexp.headers, rr)
 	}
 	r.addMatcher(rr)
 	return nil
@@ -226,11 +234,31 @@ func (m headerRegexMatcher) Match(r *http.Request, match *RouteMatch) bool {
 // The above route will only match if both the request header matches both regular expressions.
 // It the value is an empty string, it will match any value if the key is set.
 func (r *Route) HeadersRegexp(pairs ...string) *Route {
-	if r.err == nil {
-		var headers map[string]*regexp.Regexp
-		headers, r.err = mapFromPairsToRegex(pairs...)
-		return r.addMatcher(headerRegexMatcher(headers))
+	length := len(pairs)
+	if length%2 != 0 {
+		r.err = fmt.Errorf(
+			"mux: number of parameters must be multiple of 2, got %v", pairs)
+		return nil
 	}
+
+	var matchPairs []string
+	for i := 0; i < length; i += 2 {
+		if !strings.HasPrefix(pairs[i+1], "{") {
+			matchPairs = append(matchPairs, pairs[i], pairs[i+1])
+			continue
+		}
+		headerField := http.CanonicalHeaderKey(pairs[i])
+		headerValue := pairs[i+1]
+		if r.err = r.addRegexpMatcher(headerField+"="+headerValue, false, false, false, true); r.err != nil {
+			return r
+		}
+	}
+	var headers map[string]*regexp.Regexp
+	if headers, r.err = mapFromPairsToRegex(matchPairs...); r.err != nil {
+		return nil
+	}
+	r.addMatcher(headerRegexMatcher(headers))
+
 	return r
 }
 
@@ -254,7 +282,7 @@ func (r *Route) HeadersRegexp(pairs ...string) *Route {
 // Variable names must be unique in a given route. They can be retrieved
 // calling mux.Vars(request).
 func (r *Route) Host(tpl string) *Route {
-	r.err = r.addRegexpMatcher(tpl, true, false, false)
+	r.err = r.addRegexpMatcher(tpl, true, false, false, false)
 	return r
 }
 
@@ -313,7 +341,7 @@ func (r *Route) Methods(methods ...string) *Route {
 // Variable names must be unique in a given route. They can be retrieved
 // calling mux.Vars(request).
 func (r *Route) Path(tpl string) *Route {
-	r.err = r.addRegexpMatcher(tpl, false, false, false)
+	r.err = r.addRegexpMatcher(tpl, false, false, false, false)
 	return r
 }
 
@@ -329,7 +357,7 @@ func (r *Route) Path(tpl string) *Route {
 // Also note that the setting of Router.StrictSlash() has no effect on routes
 // with a PathPrefix matcher.
 func (r *Route) PathPrefix(tpl string) *Route {
-	r.err = r.addRegexpMatcher(tpl, false, true, false)
+	r.err = r.addRegexpMatcher(tpl, false, true, false, false)
 	return r
 }
 
@@ -360,7 +388,7 @@ func (r *Route) Queries(pairs ...string) *Route {
 		return nil
 	}
 	for i := 0; i < length; i += 2 {
-		if r.err = r.addRegexpMatcher(pairs[i]+"="+pairs[i+1], false, false, true); r.err != nil {
+		if r.err = r.addRegexpMatcher(pairs[i]+"="+pairs[i+1], false, false, true, false); r.err != nil {
 			return r
 		}
 	}
@@ -587,6 +615,7 @@ func (r *Route) getRegexpGroup() *routeRegexpGroup {
 			r.regexp = &routeRegexpGroup{
 				host:    regexp.host,
 				path:    regexp.path,
+				headers: regexp.headers,
 				queries: regexp.queries,
 			}
 		}


### PR DESCRIPTION
Rejigged `HeadersRegexp` a bit so that it can store regexp captures into mux's vars, per the suggestion from https://github.com/gorilla/mux/issues/126

In terms of it working just right, the bits I'm least certain about are my changes to `newRouteRegexp`. There is also a fair bit of if-else logic in various places that cycle between the different matchers cases, so those clauses could use some extra scrutiny where I had to insert changes, like in `addRegexpMatcher`.

One design consideration: the other matchers like `Path`, `Queries`, etc. require regexp strings to have braces, so `addRegexpMatcher` and related functions expect this. Since `HeadersRegexp` accepted regexp strings without braces before, I set it up so that it inserts regular matchers for non-braced strings, and uses a regexp matcher for braced strings. I don't know if using both seems too hacky or not, but I didn't want to break existing usage of the function.

What do you think @kisielk? 
