### PR TITLE
Alternative fix for #62 with speedup

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -19,3 +19,16 @@ func BenchmarkMux(b *testing.B) {
 		router.ServeHTTP(nil, request)
 	}
 }
+
+func BenchmarkMuxAlternativeInRegexp(b *testing.B) {
+	router := new(Router)
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	router.HandleFunc("/v1/{v1:(a|b)}", handler)
+
+	requestA, _ := http.NewRequest("GET", "/v1/a", nil)
+	requestB, _ := http.NewRequest("GET", "/v1/b", nil)
+	for i := 0; i < b.N; i++ {
+		router.ServeHTTP(nil, requestA)
+		router.ServeHTTP(nil, requestB)
+	}
+}

--- a/bench_test.go
+++ b/bench_test.go
@@ -6,6 +6,7 @@ package mux
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -30,5 +31,19 @@ func BenchmarkMuxAlternativeInRegexp(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		router.ServeHTTP(nil, requestA)
 		router.ServeHTTP(nil, requestB)
+	}
+}
+
+func BenchmarkManyPathVariables(b *testing.B) {
+	router := new(Router)
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	router.HandleFunc("/v1/{v1}/{v2}/{v3}/{v4}/{v5}", handler)
+
+	matchingRequest, _ := http.NewRequest("GET", "/v1/1/2/3/4/5", nil)
+	notMatchingRequest, _ := http.NewRequest("GET", "/v1/1/2/3/4", nil)
+	recorder := httptest.NewRecorder()
+	for i := 0; i < b.N; i++ {
+		router.ServeHTTP(nil, matchingRequest)
+		router.ServeHTTP(recorder, notMatchingRequest)
 	}
 }


### PR DESCRIPTION
This is an alternative way to fix #62 . Current fix uses named groups and access matches via SubexpNames. Alternative is to wrap regexp expressions in normal groups iff whole expression is not already in a group. To access only mux provided group matches it is enough to use non overlapping ranges from FindStringSubmatchIndex. Adding 2 benchamrks shows runtime speedup and decreased allocations:

```
benchmark                             old ns/op     new ns/op     delta
BenchmarkMux-4                        4916          4179          -14.99%
BenchmarkMuxAlternativeInRegexp-4     7817          6198          -20.71%
BenchmarkManyPathVariables-4          9885          8625          -12.75%

benchmark                             old allocs     new allocs     delta
BenchmarkMux-4                        11             8              -27.27%
BenchmarkMuxAlternativeInRegexp-4     22             16             -27.27%
BenchmarkManyPathVariables-4          23             12             -47.83%

benchmark                             old bytes     new bytes     delta
BenchmarkMux-4                        832           768           -7.69%
BenchmarkMuxAlternativeInRegexp-4     1728          1536          -11.11%
BenchmarkManyPathVariables-4          1223          967           -20.93%
```
[old.txt](https://github.com/gorilla/mux/files/102369/old.txt)
[new.txt](https://github.com/gorilla/mux/files/102370/new.txt)
