### PR TITLE
Fix that `cleanPath` removes extra "/" for a URL in path

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -10,8 +10,14 @@ import (
 	"net/http"
 	"path"
 	"regexp"
+	"strings"
 
 	"github.com/gorilla/context"
+)
+
+const (
+	protoSep        = "://"
+	protoSepEncoded = "%3A%2F%2F"
 )
 
 // NewRouter returns a new router instance.
@@ -351,13 +357,18 @@ func cleanPath(p string) string {
 	if p[0] != '/' {
 		p = "/" + p
 	}
+	// The path can include a URL, e.g., /a/http://localhost/b.
+	// path.Clean will clean the extra '/' and make it as /a/http:/localhost/b.
+	// "://" is encoded here retain a valid URL after path.Clean
+	p = strings.Replace(p, protoSep, protoSepEncoded, -1)
 	np := path.Clean(p)
 	// path.Clean removes trailing slash except for root;
 	// put the trailing slash back if necessary.
 	if p[len(p)-1] == '/' && np != "/" {
 		np += "/"
 	}
-	return np
+	// Decoding the "://" part
+	return strings.Replace(np, protoSepEncoded, protoSep, -1)
 }
 
 // uniqueVars returns an error if two slices contain duplicated strings.

--- a/mux_test.go
+++ b/mux_test.go
@@ -1269,8 +1269,6 @@ func (ho TestA301ResponseWriter) WriteHeader(code int) {
 }
 
 func Test301Redirect(t *testing.T) {
-	m := make(http.Header)
-
 	func1 := func(w http.ResponseWriter, r *http.Request) {}
 	func2 := func(w http.ResponseWriter, r *http.Request) {}
 
@@ -1280,6 +1278,7 @@ func Test301Redirect(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "http://localhost//api/?abc=def", nil)
 
+	m := make(http.Header)
 	res := TestA301ResponseWriter{
 		hh:     m,
 		status: 0,
@@ -1288,6 +1287,19 @@ func Test301Redirect(t *testing.T) {
 
 	if "http://localhost/api/?abc=def" != res.hh["Location"][0] {
 		t.Errorf("Should have complete URL with query string")
+	}
+
+	req, _ = http.NewRequest("GET", "http://localhost/api/http://localhost/foo", nil)
+
+	m = make(http.Header)
+	res = TestA301ResponseWriter{
+		hh:     m,
+		status: 0,
+	}
+	r.ServeHTTP(&res, req)
+
+	if _, ok := res.hh["Location"]; ok {
+		t.Errorf("Shouldn't redirect since it's a valid URL")
 	}
 }
 


### PR DESCRIPTION
A path can contain a URL, e.g., /a/http://localhost/b. `path.Clean`
removes the extra "/" in "://" and makes the path look like /a/http:/localhost/b.