### PR TITLE
Allowing case insensitive regexp groups after PR #144

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -370,6 +370,16 @@ func TestPath(t *testing.T) {
 			path_template: `/{product-category:a|(b/c)}/{product-name}/{product-id:[0-9]+}`,
 			shouldMatch:   true,
 		},
+		{
+			title:         "Path route with multiple hyphenated names and patterns with pipe and case insensitive, match",
+			route:         new(Route).Path("/{type:(?i:daily|mini|variety)}-{date:\\d{4,4}-\\d{2,2}-\\d{2,2}}"),
+			request:       newRequest("GET", "http://localhost/daily-2016-01-01"),
+			vars:          map[string]string{"type": "daily", "date": "2016-01-01"},
+			host:          "",
+			path:          "/daily-2016-01-01",
+			path_template: `/{type:(?i:daily|mini|variety)}-{date:\d{4,4}-\d{2,2}-\d{2,2}}`,
+			shouldMatch:   true,
+		},
 	}
 
 	for _, test := range tests {

--- a/regexp.go
+++ b/regexp.go
@@ -73,11 +73,8 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash 
 				tpl[idxs[i]:end])
 		}
 		// Build the regexp pattern.
-		if patt[0] == '(' && patt[len(patt)-1] == ')' {
-			fmt.Fprintf(pattern, "%s%s", regexp.QuoteMeta(raw), patt)
-		} else {
-			fmt.Fprintf(pattern, "%s(%s)", regexp.QuoteMeta(raw), patt)
-		}
+		fmt.Fprintf(pattern, "%s(?P<%s>%s)", regexp.QuoteMeta(raw), varGroupName(i/2), patt)
+
 		// Build the reverse template.
 		fmt.Fprintf(reverse, "%s%%s", raw)
 


### PR DESCRIPTION
Changes in https://github.com/gorilla/mux/pull/144 broke regexp matching for case insensitive groups. 

This adds a test scenario and a small hunk of code reverted to what it was prior to the PR.