### PR TITLE
old_test: const DefaultRemoteAddr is unused.

### DIFF
--- a/old_test.go
+++ b/old_test.go
@@ -36,10 +36,6 @@ func NewRecorder() *ResponseRecorder {
 	}
 }
 
-// DefaultRemoteAddr is the default remote address to return in RemoteAddr if
-// an explicit DefaultRemoteAddr isn't set on ResponseRecorder.
-const DefaultRemoteAddr = "1.2.3.4"
-
 // Header returns the response headers.
 func (rw *ResponseRecorder) Header() http.Header {
 	return rw.HeaderMap


### PR DESCRIPTION
const DefaultRemoteAddr is unused in old_test.