### PR TITLE
Fix golint violations

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -266,9 +266,9 @@ func (r *Router) Walk(walkFn WalkFunc) error {
 	return r.walk(walkFn, []*Route{})
 }
 
-// SkipRouter is used as a return value from WalkFuncs to indicate that the
+// ErrSkipRouter is used as a return value from WalkFuncs to indicate that the
 // router that walk is about to descend down to should be skipped.
-var SkipRouter = errors.New("skip this router")
+var ErrSkipRouter = errors.New("skip this router")
 
 // WalkFunc is the type of the function called for each route visited by Walk.
 // At every invocation, it is given the current route, and the current router,
@@ -282,7 +282,7 @@ func (r *Router) walk(walkFn WalkFunc, ancestors []*Route) error {
 		}
 
 		err := walkFn(t, r, ancestors)
-		if err == SkipRouter {
+		if err == ErrSkipRouter {
 			continue
 		}
 		for _, sr := range t.matchers {

--- a/mux_test.go
+++ b/mux_test.go
@@ -1148,7 +1148,7 @@ func TestWalkSingleDepth(t *testing.T) {
 	err := r0.Walk(func(route *Route, router *Router, ancestors []*Route) error {
 		matcher := route.matchers[0].(*routeRegexp)
 		if matcher.template == "/d" {
-			return SkipRouter
+			return ErrSkipRouter
 		}
 		if len(ancestors) != depths[i] {
 			t.Errorf(`Expected depth of %d at i = %d; got "%d"`, depths[i], i, len(ancestors))

--- a/route.go
+++ b/route.go
@@ -39,6 +39,7 @@ type Route struct {
 	buildVarsFunc BuildVarsFunc
 }
 
+// SkipClean returns whether accessing "/path//to" will not redirect
 func (r *Route) SkipClean() bool {
 	return r.skipClean
 }


### PR DESCRIPTION
This commit fixes:

```
mux.go:271:5: error var SkipRouter should have name of the form ErrFoo
route.go:42:1: exported method Route.SkipClean should have comment or be unexported
```

This commit does not fix violations on tests:

```
mux_test.go:35:2: don't use underscores in Go names; struct field path_template should be pathTemplate
mux_test.go:36:2: don't use underscores in Go names; struct field host_template should be hostTemplate
mux_test.go:1299:2: don't use underscores in Go names; var path_template should be pathTemplate
mux_test.go:1303:2: don't use underscores in Go names; var host_template should be hostTemplate
mux_test.go:1308:2: don't use underscores in Go names; var path_tmpl should be pathTmpl
mux_test.go:1308:13: don't use underscores in Go names; var path_err should be pathErr
mux_test.go:1313:2: don't use underscores in Go names; var host_tmpl should be hostTmpl
mux_test.go:1313:13: don't use underscores in Go names; var host_err should be hostErr
```