### PR TITLE
Log ListenAndServe's err response in Full Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ package main
 
 import (
 	"net/http"
-
+	"log"
 	"github.com/gorilla/mux"
 )
 
@@ -233,7 +233,7 @@ func main() {
 	r.HandleFunc("/", YourHandler)
 
 	// Bind to a port and pass our router in
-	http.ListenAndServe(":8000", r)
+	log.Fatal(http.ListenAndServe(":8000", r))
 }
 ```
 


### PR DESCRIPTION
As someone new to Go and still learning Go idioms, I spent a little bit too long diagnose why
the `ListenAndServe` call wasn't blocking. The reason is returned as an error but the full example in the README does not log the return value. My reason was port 8000 was occupied on my machine.

The examples [here](https://golang.org/pkg/net/http/) wrap `ListenAndServe` in `log.Fatal` so I'm guessing this is an idiom.

Might save someone a few mins of scratching their head, particularly if they're new to Go, like me.

