### PR TITLE
Fix error handling in  Router.Walk

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -285,6 +285,9 @@ func (r *Router) walk(walkFn WalkFunc, ancestors []*Route) error {
 		if err == SkipRouter {
 			continue
 		}
+		if err != nil {
+			return err
+		}
 		for _, sr := range t.matchers {
 			if h, ok := sr.(*Router); ok {
 				err := h.walk(walkFn, ancestors)


### PR DESCRIPTION
In old version error was not returned properly, In one walkFn call
error was checked only for SkipRouter but not for nil.