### PR TITLE
Make the new getPath method safer, fixing panics within App Engine

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -369,12 +369,8 @@ func getPath(req *http.Request) string {
 		// for < 1.5 server side workaround
 		// http://localhost/path/here?v=1 -> /path/here
 		path := req.RequestURI
-		if i := len(req.URL.Scheme); i > 0 {
-			path = path[i+len(`://`):]
-		}
-		if i := len(req.URL.Host); i > 0 {
-			path = path[i:]
-		}
+		path = strings.TrimPrefix(path, req.URL.Scheme+`://`)
+		path = strings.TrimPrefix(path, req.URL.Host)
 		if i := strings.LastIndex(path, "?"); i > -1 {
 			path = path[:i]
 		}

--- a/mux_test.go
+++ b/mux_test.go
@@ -293,6 +293,20 @@ func TestPath(t *testing.T) {
 			shouldMatch:  true,
 		},
 		{
+			title: "Path route, match root with no host, App Engine format",
+			route: new(Route).Path("/"),
+			request: func() *http.Request {
+				r := newRequest("GET", "http://localhost/")
+				r.RequestURI = "/"
+				return r
+			}(),
+			vars:         map[string]string{},
+			host:         "",
+			path:         "/",
+			pathTemplate: `/`,
+			shouldMatch:  true,
+		},
+		{
 			title:       "Path route, wrong path in request in request URL",
 			route:       new(Route).Path("/111/222/333"),
 			request:     newRequest("GET", "http://localhost/1/2/3"),


### PR DESCRIPTION
This PR fixes a panic introduces by PR https://github.com/gorilla/mux/pull/184 that manifests within Google App Engine. For more information about the underlying problem, see issue https://github.com/gorilla/mux/issues/188.

Basically, certain assumptions about the value of `RequestURI` don't hold within the App Engine sandbox environment.