### PR TITLE
Suppport for root path in a Subrouter to be routable

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -1017,6 +1017,8 @@ func TestBuildVarsFunc(t *testing.T) {
 func TestSubRouter(t *testing.T) {
 	subrouter1 := new(Route).Host("{v1:[a-z]+}.google.com").Subrouter()
 	subrouter2 := new(Route).PathPrefix("/foo/{v1}").Subrouter()
+	subrouter3 := NewRouter().StrictSlash(true).PathPrefix("/prefix/").Subrouter()
+	subrouter4 := NewRouter().PathPrefix("/prefix").Subrouter()
 
 	tests := []routeTest{
 		{
@@ -1056,6 +1058,66 @@ func TestSubRouter(t *testing.T) {
 			path:         "/foo/bar/baz/ding",
 			pathTemplate: `/foo/{v1}/baz/{v2}`,
 			shouldMatch:  false,
+		},
+		{
+			route:       subrouter3.Path("/"),
+			request:     newRequest("GET", "http://localhost/prefix/"),
+			host:        "",
+			path:        "/prefix/",
+			shouldMatch: true,
+		},
+		{
+			route:          subrouter3.Path(""),
+			request:        newRequest("GET", "http://localhost/prefix/"),
+			host:           "",
+			path:           "/prefix",
+			shouldMatch:    true,
+			shouldRedirect: true,
+		},
+		{
+			route:       subrouter3.Path(""),
+			request:     newRequest("GET", "http://localhost/prefix"),
+			host:        "",
+			path:        "/prefix",
+			shouldMatch: true,
+		},
+		{
+			route:          subrouter3.Path("/path"),
+			request:        newRequest("GET", "http://localhost/prefix/path/"),
+			host:           "",
+			path:           "/prefix/path",
+			shouldMatch:    true,
+			shouldRedirect: true,
+		},
+		{
+			route:          subrouter3.Path("/path/"),
+			request:        newRequest("GET", "http://localhost/prefix/path/"),
+			host:           "",
+			path:           "/prefix/path/",
+			shouldMatch:    true,
+			shouldRedirect: false,
+		},
+		{
+			route:          subrouter3.Path("/path/"),
+			request:        newRequest("GET", "http://localhost/prefix/path"),
+			host:           "",
+			path:           "/prefix/path/",
+			shouldMatch:    true,
+			shouldRedirect: true,
+		},
+		{
+			route:       subrouter4.Path(""),
+			request:     newRequest("GET", "http://localhost/prefix"),
+			host:        "",
+			path:        "/prefix",
+			shouldMatch: true,
+		},
+		{
+			route:       subrouter4.Path("/"),
+			request:     newRequest("GET", "http://localhost/prefix"),
+			host:        "",
+			path:        "/prefix/",
+			shouldMatch: false,
 		},
 	}
 

--- a/route.go
+++ b/route.go
@@ -153,7 +153,7 @@ func (r *Route) addRegexpMatcher(tpl string, matchHost, matchPrefix, matchQuery 
 	}
 	r.regexp = r.getRegexpGroup()
 	if !matchHost && !matchQuery {
-		if len(tpl) == 0 || tpl[0] != '/' {
+		if r.parent == nil && (len(tpl) == 0 || tpl[0] != '/') {
 			return fmt.Errorf("mux: path must start with a slash, got %q", tpl)
 		}
 		if r.regexp.path != nil {


### PR DESCRIPTION
Root paths in a SubRouter are now routable. 
I added some tests based on  #153  but not sure if other cases must be included. 