### PR TITLE
using context package in go 1.7+

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,17 @@
+// +build go1.7
+
+package mux
+
+import (
+	"context"
+	"net/http"
+)
+
+func init() {
+	contextSet = func(r *http.Request, key, val interface{}) *http.Request {
+		return r.WithContext(context.WithValue(r.Context(), key, val))
+	}
+	contextGet = func(r *http.Request, key interface{}) interface{} {
+		return r.Context().Value(key)
+	}
+}


### PR DESCRIPTION
I made some package variables to hold functions to get and set context values. In go 1.7+, these will be replaced with passthroughs to go's `context` package, and in prior versions, they will still use `gorilla/context` as always.

Still clear `gorilla/context` at the end of each request, so as to not break people using sessions with mux or similar use cases.

This should solve #204 