### PR TITLE
Added information to a route for documentation (Methods).

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The name mux stands for "HTTP request multiplexer". Like the standard `http.Serv
 * [Static Files](#static-files)
 * [Registered URLs](#registered-urls)
 * [Full Example](#full-example)
+* [Retrieving Information](#retrieving-information)
 
 ---
 
@@ -292,6 +293,23 @@ func main() {
 	// Bind to a port and pass our router in
 	log.Fatal(http.ListenAndServe(":8000", r))
 }
+```
+
+## Retrieving Information
+
+Using Walk and GetInformation it is possible to build a list of all the routes for a Router:
+
+```go
+r := mux.NewRouter()
+r.HandleFunc("/", HomeHandler).Methods("GET")
+r.HandleFunc("/products", ProductsHandler).Methods("GET", "POST")
+r.HandleFunc("/articles", ArticlesHandler).Methods("GET")
+r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+    template, _ := route.GetPathTemplate()
+    method, _ := route.GetInformation(mux.InformationMethods)
+    fmt.Println("[" + method + "]: " + template)
+    return nil
+})
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -304,12 +304,14 @@ r := mux.NewRouter()
 r.HandleFunc("/", HomeHandler).Methods("GET")
 r.HandleFunc("/products", ProductsHandler).Methods("GET", "POST")
 r.HandleFunc("/articles", ArticlesHandler).Methods("GET")
-r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+if err := r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
     template, _ := route.GetPathTemplate()
     method, _ := route.GetInformation(mux.InformationMethods)
     fmt.Println("[" + method + "]: " + template)
     return nil
-})
+}); err != nil {
+    // Handle error
+}
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -307,11 +307,11 @@ r.HandleFunc("/articles", ArticlesHandler).Methods("GET")
 if err := r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
     template, err := route.GetPathTemplate()
     if err != nil {
-        return
+        return err
     }
     method, err := route.GetInformation(mux.InformationMethods)
     if err != nil {
-        return
+        return err
     }
     fmt.Println("[" + method + "]: " + template)
     return nil

--- a/README.md
+++ b/README.md
@@ -305,8 +305,14 @@ r.HandleFunc("/", HomeHandler).Methods("GET")
 r.HandleFunc("/products", ProductsHandler).Methods("GET", "POST")
 r.HandleFunc("/articles", ArticlesHandler).Methods("GET")
 if err := r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
-    template, _ := route.GetPathTemplate()
-    method, _ := route.GetInformation(mux.InformationMethods)
+    template, err := route.GetPathTemplate()
+    if err != nil {
+        return
+    }
+    method, err := route.GetInformation(mux.InformationMethods)
+    if err != nil {
+        return
+    }
     fmt.Println("[" + method + "]: " + template)
     return nil
 }); err != nil {

--- a/mux_test.go
+++ b/mux_test.go
@@ -1519,6 +1519,30 @@ func TestSubrouterHeader(t *testing.T) {
 	}
 }
 
+func TestGetInformation(t *testing.T) {
+	infoTests := []struct {
+		route    *Route
+		info     string
+		expected string
+		err      error
+	}{
+		{new(Route), InformationMethods, "", nil},
+		{new(Route).Methods("GET"), InformationMethods, "GET", nil},
+		{new(Route).Methods("GET", "POST"), InformationMethods, "GET,POST", nil},
+		{new(Route).Methods("GET").Methods("POST"), InformationMethods, "GET,POST", nil},
+	}
+
+	for _, test := range infoTests {
+		actual, err := test.route.GetInformation(test.info)
+		if actual != test.expected {
+			t.Errorf("Expected result '%s', got '%s' when retrieving '%s'", test.expected, actual, test.info)
+		}
+		if err != test.err {
+			t.Errorf("Expected error '%v', got '%v' when retrieving '%s'", test.err, err.Error(), test.info)
+		}
+	}
+}
+
 // mapToPairs converts a string map to a slice of string pairs
 func mapToPairs(m map[string]string) []string {
 	var i int

--- a/route.go
+++ b/route.go
@@ -674,11 +674,11 @@ func (r *Route) GetInformation(name string) (string, error) {
 		return "", r.err
 	}
 	if r.information == nil {
-		return "", errors.New("mux: route has no information")
+		return "", nil
 	}
 	information, ok := r.information[name]
 	if !ok {
-		return "", errors.New("mux: information '" + name + "' has not been set")
+		return "", nil
 	}
 	return information, nil
 }


### PR DESCRIPTION
This patch allows adding additional information to a route. This allows for automatic generation of documentation about a route.

At the moment, the only information associated with a route is the methods.

This can be combined with the Walk() function to allow something like this:
`func documentRoute(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {`
`template, _ := route.GetPathTemplate()`
`method, _ := route.GetInformation(mux.InformationMethods)`
`fmt.Println("[" + method + "]" + template)`
`return nil`
`}`
