### PR TITLE
Add support for queries in URL reversing.

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -35,6 +35,7 @@ type routeTest struct {
 	path           string            // the expected path of the match
 	pathTemplate   string            // the expected path template to match
 	hostTemplate   string            // the expected host template to match
+	query          string            // the expected query string to match
 	shouldMatch    bool              // whether the request is expected to match the route at all
 	shouldRedirect bool              // whether the request should result in a redirect
 }
@@ -684,6 +685,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{},
 			host:        "",
 			path:        "",
+			query:       "foo=bar&baz=ding",
 			shouldMatch: true,
 		},
 		{
@@ -693,6 +695,7 @@ func TestQueries(t *testing.T) {
 			vars:         map[string]string{},
 			host:         "",
 			path:         "",
+			query:        "foo=bar&baz=ding",
 			pathTemplate: `/api`,
 			hostTemplate: `www.example.com`,
 			shouldMatch:  true,
@@ -704,6 +707,7 @@ func TestQueries(t *testing.T) {
 			vars:         map[string]string{},
 			host:         "",
 			path:         "",
+			query:        "foo=bar&baz=ding",
 			pathTemplate: `/api`,
 			hostTemplate: `www.example.com`,
 			shouldMatch:  true,
@@ -724,6 +728,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v1": "bar"},
 			host:        "",
 			path:        "",
+			query:       "foo=bar",
 			shouldMatch: true,
 		},
 		{
@@ -733,6 +738,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v1": "bar", "v2": "ding"},
 			host:        "",
 			path:        "",
+			query:       "foo=bar&baz=ding",
 			shouldMatch: true,
 		},
 		{
@@ -742,6 +748,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v1": "10"},
 			host:        "",
 			path:        "",
+			query:       "foo=10",
 			shouldMatch: true,
 		},
 		{
@@ -760,6 +767,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v1": "1"},
 			host:        "",
 			path:        "",
+			query:       "foo=1",
 			shouldMatch: true,
 		},
 		{
@@ -769,6 +777,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v1": "1"},
 			host:        "",
 			path:        "",
+			query:       "foo=1",
 			shouldMatch: true,
 		},
 		{
@@ -787,6 +796,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v1": "1a"},
 			host:        "",
 			path:        "",
+			query:       "foo=1a",
 			shouldMatch: true,
 		},
 		{
@@ -805,6 +815,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v-1": "bar"},
 			host:        "",
 			path:        "",
+			query:       "foo=bar",
 			shouldMatch: true,
 		},
 		{
@@ -814,6 +825,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v-1": "bar", "v-2": "ding"},
 			host:        "",
 			path:        "",
+			query:       "foo=bar&baz=ding",
 			shouldMatch: true,
 		},
 		{
@@ -823,6 +835,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v-1": "10"},
 			host:        "",
 			path:        "",
+			query:       "foo=10",
 			shouldMatch: true,
 		},
 		{
@@ -832,6 +845,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v-1": "1a"},
 			host:        "",
 			path:        "",
+			query:       "foo=1a",
 			shouldMatch: true,
 		},
 		{
@@ -841,6 +855,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{},
 			host:        "",
 			path:        "",
+			query:       "foo=",
 			shouldMatch: true,
 		},
 		{
@@ -859,6 +874,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{},
 			host:        "",
 			path:        "",
+			query:       "foo=",
 			shouldMatch: true,
 		},
 		{
@@ -886,6 +902,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"foo": ""},
 			host:        "",
 			path:        "",
+			query:       "foo=",
 			shouldMatch: true,
 		},
 		{
@@ -1423,6 +1440,7 @@ func testRoute(t *testing.T, test routeTest) {
 	host := test.host
 	path := test.path
 	url := test.host + test.path
+	query := test.query
 	shouldRedirect := test.shouldRedirect
 
 	var match RouteMatch
@@ -1458,6 +1476,13 @@ func testRoute(t *testing.T, test routeTest) {
 			u, _ := route.URL(mapToPairs(match.Vars)...)
 			if url != u.Host+u.Path {
 				t.Errorf("(%v) URL not equal: expected %v, got %v -- %v", test.title, url, u.Host+u.Path, getRouteTemplate(route))
+				return
+			}
+		}
+		if query != "" {
+			u, _ := route.URL(mapToPairs(match.Vars)...)
+			if query != u.RawQuery {
+				t.Errorf("(%v) URL query not equal: expected %v, got %v", test.title, query, u.RawQuery)
 				return
 			}
 		}

--- a/regexp.go
+++ b/regexp.go
@@ -178,6 +178,9 @@ func (r *routeRegexp) url(values map[string]string) (string, error) {
 		if !ok {
 			return "", fmt.Errorf("mux: missing route variable %q", v)
 		}
+		if r.matchQuery {
+			value = url.QueryEscape(value)
+		}
 		urlValues[k] = value
 	}
 	rv := fmt.Sprintf(r.reverse, urlValues...)

--- a/route.go
+++ b/route.go
@@ -477,6 +477,7 @@ func (r *Route) URL(pairs ...string) (*url.URL, error) {
 		return nil, err
 	}
 	var scheme, host, path string
+	queries := make([]string, 0, len(r.regexp.queries))
 	if r.regexp.host != nil {
 		// Set a default scheme.
 		scheme = "http"
@@ -489,10 +490,18 @@ func (r *Route) URL(pairs ...string) (*url.URL, error) {
 			return nil, err
 		}
 	}
+	for _, q := range r.regexp.queries {
+		var query string
+		if query, err = q.url(values); err != nil {
+			return nil, err
+		}
+		queries = append(queries, query)
+	}
 	return &url.URL{
-		Scheme: scheme,
-		Host:   host,
-		Path:   path,
+		Scheme:   scheme,
+		Host:     host,
+		Path:     path,
+		RawQuery: strings.Join(queries, "&"),
 	}, nil
 }
 


### PR DESCRIPTION
This patch allows generating an URL for a route with query parameters.

Here is an example:
```
func main() {
    router := mux.NewRouter()
    router.Path("/items/{item}").Queries("version", "{version}").Name("item")
    u, _ := router.GetRoute("item").URL("item", "123", "version", "5")
    fmt.Println(u.String())
}
```
Output:
`/items/123?version=5`