### PR TITLE
Any changes to context, etc will be preserved in the original Request

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -102,8 +102,9 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var handler http.Handler
 	if r.Match(req, &match) {
 		handler = match.Handler
-		req = setVars(req, match.Vars)
-		req = setCurrentRoute(req, match.Route)
+		req1 := setVars(req, match.Vars)
+		req2 := setCurrentRoute(req1, match.Route)
+		*req = *req2
 	}
 	if handler == nil {
 		handler = http.NotFoundHandler()


### PR DESCRIPTION
Any changes to context, etc will be preserved in the original http.Request object that is passed in to ServeHTTP, for reference in later middleware processing. Without this, a new Request is spun off within the current handler, and changes made to it are lost when the scope ends.