### PR TITLE
Get extra information about a route for a documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ package main
 import (
     "fmt"
     "net/http"
+    "strings"
 
     "github.com/gorilla/mux"
 )
@@ -190,15 +191,25 @@ func handler(w http.ResponseWriter, r *http.Request) {
 func main() {
     r := mux.NewRouter()
     r.HandleFunc("/", handler)
-    r.HandleFunc("/products", handler)
-    r.HandleFunc("/articles", handler)
-    r.HandleFunc("/articles/{id}", handler)
+    r.Methods("POST").HandleFunc("/products", handler)
+    r.Methods("GET").HandleFunc("/articles", handler)
+    r.Methods("GET", "PUT").HandleFunc("/articles/{id}", handler)
     r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
         t, err := route.GetPathTemplate()
         if err != nil {
             return err
         }
-        fmt.Println(t)
+        // p will contain regular expression is compatible with regular expression in Perl, Python, and other languages.
+        // for instance the regular expression for path '/articles/{id}' will be '^/articles/(?P<v0>[^/]+)$'
+        p, err := route.GetPathRegexp()
+        if err != nil {
+            return err
+        }
+        m, err := route.GetMethods()
+        if err != nil {
+            return err
+        }
+        fmt.Println(strings.Join(m, ","), t, p)
         return nil
     })
     http.Handle("/", r)

--- a/mux_test.go
+++ b/mux_test.go
@@ -35,6 +35,7 @@ type routeTest struct {
 	path           string            // the expected path of the match
 	pathTemplate   string            // the expected path template to match
 	hostTemplate   string            // the expected host template to match
+	methods        []string          // the expected route methods
 	pathRegexp     string            // the expected path regexp
 	shouldMatch    bool              // whether the request is expected to match the route at all
 	shouldRedirect bool              // whether the request should result in a redirect
@@ -660,6 +661,7 @@ func TestMethods(t *testing.T) {
 			vars:        map[string]string{},
 			host:        "",
 			path:        "",
+			methods:     []string{"GET", "POST"},
 			shouldMatch: true,
 		},
 		{
@@ -669,6 +671,7 @@ func TestMethods(t *testing.T) {
 			vars:        map[string]string{},
 			host:        "",
 			path:        "",
+			methods:     []string{"GET", "POST"},
 			shouldMatch: true,
 		},
 		{
@@ -678,13 +681,25 @@ func TestMethods(t *testing.T) {
 			vars:        map[string]string{},
 			host:        "",
 			path:        "",
+			methods:     []string{"GET", "POST"},
 			shouldMatch: false,
+		},
+		{
+			title:       "Route without methods",
+			route:       new(Route),
+			request:     newRequest("PUT", "http://localhost"),
+			vars:        map[string]string{},
+			host:        "",
+			path:        "",
+			methods:     []string{},
+			shouldMatch: true,
 		},
 	}
 
 	for _, test := range tests {
 		testRoute(t, test)
 		testTemplate(t, test)
+		testMethods(t, test)
 	}
 }
 
@@ -1509,6 +1524,14 @@ func testTemplate(t *testing.T, test routeTest) {
 	routeHostTemplate, hostErr := route.GetHostTemplate()
 	if hostErr == nil && routeHostTemplate != hostTemplate {
 		t.Errorf("(%v) GetHostTemplate not equal: expected %v, got %v", test.title, hostTemplate, routeHostTemplate)
+	}
+}
+
+func testMethods(t *testing.T, test routeTest) {
+	route := test.route
+	methods, _ := route.GetMethods()
+	if strings.Join(methods, ",") != strings.Join(test.methods, ",") {
+		t.Errorf("(%v) GetMethods not equal: expected %v, got %v", test.title, test.methods, methods)
 	}
 }
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -35,6 +35,7 @@ type routeTest struct {
 	path           string            // the expected path of the match
 	pathTemplate   string            // the expected path template to match
 	hostTemplate   string            // the expected host template to match
+	pathRegexp     string            // the expected path regexp
 	shouldMatch    bool              // whether the request is expected to match the route at all
 	shouldRedirect bool              // whether the request should result in a redirect
 }
@@ -270,6 +271,7 @@ func TestPath(t *testing.T) {
 			host:         "",
 			path:         "/111",
 			pathTemplate: `/111/`,
+			pathRegexp:   `^/111/$`,
 			shouldMatch:  false,
 		},
 		{
@@ -290,6 +292,7 @@ func TestPath(t *testing.T) {
 			host:         "",
 			path:         "/",
 			pathTemplate: `/`,
+			pathRegexp:   `^/$`,
 			shouldMatch:  true,
 		},
 		{
@@ -333,6 +336,7 @@ func TestPath(t *testing.T) {
 			host:         "",
 			path:         "/111/222/333",
 			pathTemplate: `/111/{v1:[0-9]{3}}/333`,
+			pathRegexp:   `^/111/(?P<v0>[0-9]{3})/333$`,
 			shouldMatch:  false,
 		},
 		{
@@ -343,6 +347,7 @@ func TestPath(t *testing.T) {
 			host:         "",
 			path:         "/111/222/333",
 			pathTemplate: `/{v1:[0-9]{3}}/{v2:[0-9]{3}}/{v3:[0-9]{3}}`,
+			pathRegexp:   `^/(?P<v0>[0-9]{3})/(?P<v1>[0-9]{3})/(?P<v2>[0-9]{3})$`,
 			shouldMatch:  true,
 		},
 		{
@@ -353,6 +358,7 @@ func TestPath(t *testing.T) {
 			host:         "",
 			path:         "/111/222/333",
 			pathTemplate: `/{v1:[0-9]{3}}/{v2:[0-9]{3}}/{v3:[0-9]{3}}`,
+			pathRegexp:   `^/(?P<v0>[0-9]{3})/(?P<v1>[0-9]{3})/(?P<v2>[0-9]{3})$`,
 			shouldMatch:  false,
 		},
 		{
@@ -363,6 +369,7 @@ func TestPath(t *testing.T) {
 			host:         "",
 			path:         "/a/product_name/1",
 			pathTemplate: `/{category:a|(?:b/c)}/{product}/{id:[0-9]+}`,
+			pathRegexp:   `^/(?P<v0>a|(?:b/c))/(?P<v1>[^/]+)/(?P<v2>[0-9]+)$`,
 			shouldMatch:  true,
 		},
 		{
@@ -373,6 +380,7 @@ func TestPath(t *testing.T) {
 			host:         "",
 			path:         "/111/222/333",
 			pathTemplate: `/111/{v-1:[0-9]{3}}/333`,
+			pathRegexp:   `^/111/(?P<v0>[0-9]{3})/333$`,
 			shouldMatch:  true,
 		},
 		{
@@ -383,6 +391,7 @@ func TestPath(t *testing.T) {
 			host:         "",
 			path:         "/111/222/333",
 			pathTemplate: `/{v-1:[0-9]{3}}/{v-2:[0-9]{3}}/{v-3:[0-9]{3}}`,
+			pathRegexp:   `^/(?P<v0>[0-9]{3})/(?P<v1>[0-9]{3})/(?P<v2>[0-9]{3})$`,
 			shouldMatch:  true,
 		},
 		{
@@ -393,6 +402,7 @@ func TestPath(t *testing.T) {
 			host:         "",
 			path:         "/a/product_name/1",
 			pathTemplate: `/{product-category:a|(?:b/c)}/{product-name}/{product-id:[0-9]+}`,
+			pathRegexp:   `^/(?P<v0>a|(?:b/c))/(?P<v1>[^/]+)/(?P<v2>[0-9]+)$`,
 			shouldMatch:  true,
 		},
 		{
@@ -403,6 +413,7 @@ func TestPath(t *testing.T) {
 			host:         "",
 			path:         "/daily-2016-01-01",
 			pathTemplate: `/{type:(?i:daily|mini|variety)}-{date:\d{4,4}-\d{2,2}-\d{2,2}}`,
+			pathRegexp:   `^/(?P<v0>(?i:daily|mini|variety))-(?P<v1>\d{4,4}-\d{2,2}-\d{2,2})$`,
 			shouldMatch:  true,
 		},
 		{
@@ -413,6 +424,7 @@ func TestPath(t *testing.T) {
 			host:         "",
 			path:         "/111/222",
 			pathTemplate: `/{v1:[0-9]*}{v2:[a-z]*}/{v3:[0-9]*}`,
+			pathRegexp:   `^/(?P<v0>[0-9]*)(?P<v1>[a-z]*)/(?P<v2>[0-9]*)$`,
 			shouldMatch:  true,
 		},
 	}
@@ -421,6 +433,7 @@ func TestPath(t *testing.T) {
 		testRoute(t, test)
 		testTemplate(t, test)
 		testUseEscapedRoute(t, test)
+		testRegexp(t, test)
 	}
 }
 
@@ -1496,6 +1509,14 @@ func testTemplate(t *testing.T, test routeTest) {
 	routeHostTemplate, hostErr := route.GetHostTemplate()
 	if hostErr == nil && routeHostTemplate != hostTemplate {
 		t.Errorf("(%v) GetHostTemplate not equal: expected %v, got %v", test.title, hostTemplate, routeHostTemplate)
+	}
+}
+
+func testRegexp(t *testing.T, test routeTest) {
+	route := test.route
+	routePathRegexp, regexpErr := route.GetPathRegexp()
+	if test.pathRegexp != "" && regexpErr == nil && routePathRegexp != test.pathRegexp {
+		t.Errorf("(%v) GetPathRegexp not equal: expected %v, got %v", test.title, test.pathRegexp, routePathRegexp)
 	}
 }
 

--- a/route.go
+++ b/route.go
@@ -572,6 +572,22 @@ func (r *Route) GetPathRegexp() (string, error) {
 	return r.regexp.path.regexp.String(), nil
 }
 
+// GetMethods returns the methods the route matches against
+// This is useful for building simple REST API documentation and for instrumentation
+// against third-party services.
+// An empty list will be returned if route does not have methods.
+func (r *Route) GetMethods() ([]string, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	for _, m := range r.matchers {
+		if methods, ok := m.(methodMatcher); ok {
+			return []string(methods), nil
+		}
+	}
+	return nil, nil
+}
+
 // GetHostTemplate returns the template used to build the
 // route match.
 // This is useful for building simple REST API documentation and for instrumentation

--- a/route.go
+++ b/route.go
@@ -558,6 +558,20 @@ func (r *Route) GetPathTemplate() (string, error) {
 	return r.regexp.path.template, nil
 }
 
+// GetPathRegexp returns the expanded regular expression used to match route path.
+// This is useful for building simple REST API documentation and for instrumentation
+// against third-party services.
+// An error will be returned if the route does not define a path.
+func (r *Route) GetPathRegexp() (string, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	if r.regexp == nil || r.regexp.path == nil {
+		return "", errors.New("mux: route does not have a path")
+	}
+	return r.regexp.path.regexp.String(), nil
+}
+
 // GetHostTemplate returns the template used to build the
 // route match.
 // This is useful for building simple REST API documentation and for instrumentation


### PR DESCRIPTION
Add method `GetPathRegexp`  which returns original regex for path.
Add method `GetMethods` which returns all available methods for path.