### PR TITLE
Router.AddRoute()

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -209,9 +209,18 @@ func (r *Router) buildVars(m map[string]string) map[string]string {
 
 // NewRoute registers an empty route.
 func (r *Router) NewRoute() *Route {
-	route := &Route{parent: r, strictSlash: r.strictSlash, skipClean: r.skipClean, useEncodedPath: r.useEncodedPath}
-	r.routes = append(r.routes, route)
+	route := &Route{}
+	r.AddRoute(route)
 	return route
+}
+
+// AddRoute registers a route
+func (r *Router) AddRoute(route *Route) {
+	route.parent = r
+	route.strictSlash = r.strictSlash
+	route.skipClean = r.skipClean
+	route.useEncodedPath = r.useEncodedPath
+	r.routes = append(r.routes, route)
 }
 
 // Handle registers a new route with a matcher for the URL path.

--- a/mux_test.go
+++ b/mux_test.go
@@ -1389,6 +1389,24 @@ func TestSubrouterErrorHandling(t *testing.T) {
 	}
 }
 
+func TestAddRoute(t *testing.T) {
+	handled := false
+	route := &Route{}
+	route = route.Name("one").Path("/111")
+	route = route.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handled = true
+	})
+
+	router := NewRouter()
+	router.AddRoute(route)
+
+	req, _ := http.NewRequest("GET", "http://localhost/111", nil)
+	router.ServeHTTP(NewRecorder(), req)
+	if !handled {
+		t.Error("Route was not added to the Router.")
+	}
+}
+
 // See: https://github.com/gorilla/mux/issues/200
 func TestPanicOnCapturingGroups(t *testing.T) {
 	defer func() {


### PR DESCRIPTION
I'd like to build up `Route` objects before creating the router. I've run into this a couple times, and I'm wondering if you would accept this PR for an `AddRoute()` method on `Router`.