### PR TITLE
Fixed golint warning

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -288,9 +288,9 @@ func (r *Router) Walk(walkFn WalkFunc) error {
 	return r.walk(walkFn, []*Route{})
 }
 
-// SkipRouter is used as a return value from WalkFuncs to indicate that the
+// ErrSkipRouter is used as a return value from WalkFuncs to indicate that the
 // router that walk is about to descend down to should be skipped.
-var SkipRouter = errors.New("skip this router")
+var ErrSkipRouter = errors.New("skip this router")
 
 // WalkFunc is the type of the function called for each route visited by Walk.
 // At every invocation, it is given the current route, and the current router,
@@ -304,7 +304,7 @@ func (r *Router) walk(walkFn WalkFunc, ancestors []*Route) error {
 		}
 
 		err := walkFn(t, r, ancestors)
-		if err == SkipRouter {
+		if err == ErrSkipRouter {
 			continue
 		}
 		if err != nil {

--- a/mux_test.go
+++ b/mux_test.go
@@ -1280,7 +1280,7 @@ func TestWalkSingleDepth(t *testing.T) {
 	err := r0.Walk(func(route *Route, router *Router, ancestors []*Route) error {
 		matcher := route.matchers[0].(*routeRegexp)
 		if matcher.template == "/d" {
-			return SkipRouter
+			return ErrSkipRouter
 		}
 		if len(ancestors) != depths[i] {
 			t.Errorf(`Expected depth of %d at i = %d; got "%d"`, depths[i], i, len(ancestors))


### PR DESCRIPTION
Errors should be prefixed with `Err` according to golint...