### PR TITLE
Add BeforeHandler to mux.Router

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -39,6 +39,11 @@ func NewRouter() *Router {
 type Router struct {
 	// Configurable Handler to be used when no route matches.
 	NotFoundHandler http.Handler
+	// BeforeHandler is a handler that is always invoked before the primary handler.
+	// It is invoked whether or not a matching handler is found. Only the root router
+	// (the one running the ServeHTTP function) invokes its BeforeHandler -- any
+	// BeforeHandler functions that might exist on subrouters are ignored.
+	BeforeHandler http.Handler
 	// Parent route, if this is a subrouter.
 	parent parentRoute
 	// Routes to be matched, in order.
@@ -110,6 +115,9 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	if !r.KeepContext {
 		defer contextClear(req)
+	}
+	if r.BeforeHandler != nil {
+		r.BeforeHandler.ServeHTTP(w, req)
 	}
 	handler.ServeHTTP(w, req)
 }

--- a/mux_test.go
+++ b/mux_test.go
@@ -1124,6 +1124,91 @@ func TestSubRouter(t *testing.T) {
 	}
 }
 
+func TestBeforeHandlerCalled(t *testing.T) {
+	tests := []struct {
+		path      string
+		wantMatch bool
+	}{
+		{"http://aaa.google.com/nomatch", false},
+		{"http://aaa.google.com/test", true},
+	}
+
+	for _, test := range tests {
+		router := new(Route).Host("{v1:[a-z]+}.google.com").Subrouter()
+		beforeCalled := false
+		router.BeforeHandler = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			beforeCalled = true
+		})
+
+		matched := false
+		router.Path("/test").HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			matched = true
+		})
+
+		router.ServeHTTP(NewRecorder(), newRequest("GET", test.path))
+
+		if matched != test.wantMatch {
+			t.Errorf("expected URL %s to match router", test.path)
+		}
+
+		if !beforeCalled {
+			t.Error("BeforeHandler should always be called")
+		}
+	}
+}
+
+func TestBeforeHandlerSubrouters(t *testing.T) {
+	tests := []struct {
+		path           string
+		wantFooMatched bool
+		wantBarMatched bool
+	}{
+		{"http://google.com/foo", true, false},
+		{"http://google.com/bar/", false, true},
+	}
+
+	for _, test := range tests {
+		router := NewRouter()
+		rootBeforeCalled := false
+		router.BeforeHandler = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rootBeforeCalled = true
+		})
+
+		domainRouter := router.Host("google.com").Subrouter()
+
+		fooMatched := false
+		domainRouter.HandleFunc("/foo", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			fooMatched = true
+		}))
+
+		barSubrouter := domainRouter.PathPrefix("/bar").Subrouter()
+		subrouterBeforeCalled := false
+		barSubrouter.BeforeHandler = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			subrouterBeforeCalled = true
+		})
+
+		barMatched := false
+		barSubrouter.HandleFunc("/", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			barMatched = true
+		}))
+
+		router.ServeHTTP(NewRecorder(), newRequest("GET", test.path))
+
+		if !rootBeforeCalled {
+			t.Errorf("root BeforeHandler should always be called")
+		}
+		if fooMatched != test.wantFooMatched {
+			t.Errorf("fooMatched != wantFooMatched: %v != %v", fooMatched, test.wantFooMatched)
+		}
+		if subrouterBeforeCalled {
+			t.Errorf("subrouter BeforeHandler should never be called")
+		}
+		if barMatched != test.wantBarMatched {
+			t.Errorf("barMatched != wantBarMatched: %v != %v", barMatched, test.wantBarMatched)
+		}
+	}
+}
+
 func TestNamedRoutes(t *testing.T) {
 	r1 := NewRouter()
 	r1.NewRoute().Name("a")


### PR DESCRIPTION
Adds the ability to register a handler on the root Router that is
always invoked before the matched handler or NotFoundHandler.

Fixes #258