### PR TITLE
Support building URLs with non-http schemes.

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012 The Gorilla Authors. All rights reserved.
+﻿// Copyright 2012 The Gorilla Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -31,10 +31,10 @@ type routeTest struct {
 	route          *Route            // the route being tested
 	request        *http.Request     // a request to test the route
 	vars           map[string]string // the expected vars of the match
-	host           string            // the expected host of the match
-	path           string            // the expected path of the match
-	pathTemplate   string            // the expected path template to match
-	hostTemplate   string            // the expected host template to match
+	host           string            // the expected host of the built URL
+	path           string            // the expected path of the built URL
+	pathTemplate   string            // the expected path template of the route
+	hostTemplate   string            // the expected host template of the route
 	methods        []string          // the expected route methods
 	pathRegexp     string            // the expected path regexp
 	shouldMatch    bool              // whether the request is expected to match the route at all
@@ -195,46 +195,6 @@ func TestHost(t *testing.T) {
 			host:         "aaa.bbb.ccc",
 			path:         "",
 			hostTemplate: `{v-1:[a-z]{3}}.{v-2:[a-z]{3}}.{v-3:[a-z]{3}}`,
-			shouldMatch:  true,
-		},
-		{
-			title:        "Path route with single pattern with pipe, match",
-			route:        new(Route).Path("/{category:a|b/c}"),
-			request:      newRequest("GET", "http://localhost/a"),
-			vars:         map[string]string{"category": "a"},
-			host:         "",
-			path:         "/a",
-			pathTemplate: `/{category:a|b/c}`,
-			shouldMatch:  true,
-		},
-		{
-			title:        "Path route with single pattern with pipe, match",
-			route:        new(Route).Path("/{category:a|b/c}"),
-			request:      newRequest("GET", "http://localhost/b/c"),
-			vars:         map[string]string{"category": "b/c"},
-			host:         "",
-			path:         "/b/c",
-			pathTemplate: `/{category:a|b/c}`,
-			shouldMatch:  true,
-		},
-		{
-			title:        "Path route with multiple patterns with pipe, match",
-			route:        new(Route).Path("/{category:a|b/c}/{product}/{id:[0-9]+}"),
-			request:      newRequest("GET", "http://localhost/a/product_name/1"),
-			vars:         map[string]string{"category": "a", "product": "product_name", "id": "1"},
-			host:         "",
-			path:         "/a/product_name/1",
-			pathTemplate: `/{category:a|b/c}/{product}/{id:[0-9]+}`,
-			shouldMatch:  true,
-		},
-		{
-			title:        "Path route with multiple patterns with pipe, match",
-			route:        new(Route).Path("/{category:a|b/c}/{product}/{id:[0-9]+}"),
-			request:      newRequest("GET", "http://localhost/b/c/product_name/1"),
-			vars:         map[string]string{"category": "b/c", "product": "product_name", "id": "1"},
-			host:         "",
-			path:         "/b/c/product_name/1",
-			pathTemplate: `/{category:a|b/c}/{product}/{id:[0-9]+}`,
 			shouldMatch:  true,
 		},
 	}
@@ -426,6 +386,46 @@ func TestPath(t *testing.T) {
 			path:         "/111/222",
 			pathTemplate: `/{v1:[0-9]*}{v2:[a-z]*}/{v3:[0-9]*}`,
 			pathRegexp:   `^/(?P<v0>[0-9]*)(?P<v1>[a-z]*)/(?P<v2>[0-9]*)$`,
+			shouldMatch:  true,
+		},
+		{
+			title:        "Path route with single pattern with pipe, match",
+			route:        new(Route).Path("/{category:a|b/c}"),
+			request:      newRequest("GET", "http://localhost/a"),
+			vars:         map[string]string{"category": "a"},
+			host:         "",
+			path:         "/a",
+			pathTemplate: `/{category:a|b/c}`,
+			shouldMatch:  true,
+		},
+		{
+			title:        "Path route with single pattern with pipe, match",
+			route:        new(Route).Path("/{category:a|b/c}"),
+			request:      newRequest("GET", "http://localhost/b/c"),
+			vars:         map[string]string{"category": "b/c"},
+			host:         "",
+			path:         "/b/c",
+			pathTemplate: `/{category:a|b/c}`,
+			shouldMatch:  true,
+		},
+		{
+			title:        "Path route with multiple patterns with pipe, match",
+			route:        new(Route).Path("/{category:a|b/c}/{product}/{id:[0-9]+}"),
+			request:      newRequest("GET", "http://localhost/a/product_name/1"),
+			vars:         map[string]string{"category": "a", "product": "product_name", "id": "1"},
+			host:         "",
+			path:         "/a/product_name/1",
+			pathTemplate: `/{category:a|b/c}/{product}/{id:[0-9]+}`,
+			shouldMatch:  true,
+		},
+		{
+			title:        "Path route with multiple patterns with pipe, match",
+			route:        new(Route).Path("/{category:a|b/c}/{product}/{id:[0-9]+}"),
+			request:      newRequest("GET", "http://localhost/b/c/product_name/1"),
+			vars:         map[string]string{"category": "b/c", "product": "product_name", "id": "1"},
+			host:         "",
+			path:         "/b/c/product_name/1",
+			pathTemplate: `/{category:a|b/c}/{product}/{id:[0-9]+}`,
 			shouldMatch:  true,
 		},
 	}
@@ -649,7 +649,6 @@ func TestHeaders(t *testing.T) {
 		testRoute(t, test)
 		testTemplate(t, test)
 	}
-
 }
 
 func TestMethods(t *testing.T) {

--- a/mux_test.go
+++ b/mux_test.go
@@ -1,4 +1,4 @@
-﻿// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Copyright 2012 The Gorilla Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -970,37 +970,42 @@ func TestSchemes(t *testing.T) {
 		// Schemes
 		{
 			title:       "Schemes route, default scheme, match http, build http",
-			route:       new(Route),
+			route:       new(Route).Host("localhost"),
 			request:     newRequest("GET", "http://localhost"),
 			scheme:      "http",
+			host:        "localhost",
 			shouldMatch: true,
 		},
 		{
 			title:       "Schemes route, match https, build https",
-			route:       new(Route).Schemes("https", "ftp"),
+			route:       new(Route).Schemes("https", "ftp").Host("localhost"),
 			request:     newRequest("GET", "https://localhost"),
 			scheme:      "https",
+			host:        "localhost",
 			shouldMatch: true,
 		},
 		{
 			title:       "Schemes route, match ftp, build https",
-			route:       new(Route).Schemes("https", "ftp"),
+			route:       new(Route).Schemes("https", "ftp").Host("localhost"),
 			request:     newRequest("GET", "ftp://localhost"),
 			scheme:      "https",
+			host:        "localhost",
 			shouldMatch: true,
 		},
 		{
 			title:       "Schemes route, match ftp, build ftp",
-			route:       new(Route).Schemes("ftp", "https"),
+			route:       new(Route).Schemes("ftp", "https").Host("localhost"),
 			request:     newRequest("GET", "ftp://localhost"),
 			scheme:      "ftp",
+			host:        "localhost",
 			shouldMatch: true,
 		},
 		{
 			title:       "Schemes route, bad scheme",
-			route:       new(Route).Schemes("https", "ftp"),
+			route:       new(Route).Schemes("https", "ftp").Host("localhost"),
 			request:     newRequest("GET", "http://localhost"),
 			scheme:      "https",
+			host:        "localhost",
 			shouldMatch: false,
 		},
 	}
@@ -1513,14 +1518,20 @@ func testRoute(t *testing.T, test routeTest) {
 			return
 		}
 		if test.scheme != "" {
-			u, _ := route.URLScheme()
+			u, err := route.URL(mapToPairs(match.Vars)...)
+			if err != nil {
+				t.Fatalf("(%v) URL error: %v -- %v", test.title, err, getRouteTemplate(route))
+			}
 			if uri.Scheme != u.Scheme {
 				t.Errorf("(%v) URLScheme not equal: expected %v, got %v", test.title, uri.Scheme, u.Scheme)
 				return
 			}
 		}
 		if test.host != "" {
-			u, _ := test.route.URLHost(mapToPairs(match.Vars)...)
+			u, err := test.route.URLHost(mapToPairs(match.Vars)...)
+			if err != nil {
+				t.Fatalf("(%v) URLHost error: %v -- %v", test.title, err, getRouteTemplate(route))
+			}
 			if uri.Scheme != u.Scheme {
 				t.Errorf("(%v) URLHost scheme not equal: expected %v, got %v -- %v", test.title, uri.Scheme, u.Scheme, getRouteTemplate(route))
 				return
@@ -1531,14 +1542,20 @@ func testRoute(t *testing.T, test routeTest) {
 			}
 		}
 		if test.path != "" {
-			u, _ := route.URLPath(mapToPairs(match.Vars)...)
+			u, err := route.URLPath(mapToPairs(match.Vars)...)
+			if err != nil {
+				t.Fatalf("(%v) URLPath error: %v -- %v", test.title, err, getRouteTemplate(route))
+			}
 			if uri.Path != u.Path {
 				t.Errorf("(%v) URLPath not equal: expected %v, got %v -- %v", test.title, uri.Path, u.Path, getRouteTemplate(route))
 				return
 			}
 		}
 		if test.host != "" && test.path != "" {
-			u, _ := route.URL(mapToPairs(match.Vars)...)
+			u, err := route.URL(mapToPairs(match.Vars)...)
+			if err != nil {
+				t.Fatalf("(%v) URL error: %v -- %v", test.title, err, getRouteTemplate(route))
+			}
 			if expected, got := uri.String(), u.String(); expected != got {
 				t.Errorf("(%v) URL not equal: expected %v, got %v -- %v", test.title, expected, got, getRouteTemplate(route))
 				return

--- a/route.go
+++ b/route.go
@@ -503,23 +503,6 @@ func (r *Route) URL(pairs ...string) (*url.URL, error) {
 	}, nil
 }
 
-// URLScheme builds the scheme part of the URL for a route. See Route.URL().
-//
-// A route with multiple schemes will return the first scheme of the route. A
-// route with no schemes will return "http" as the scheme.
-func (r *Route) URLScheme() (*url.URL, error) {
-	if r.err != nil {
-		return nil, r.err
-	}
-	u := &url.URL{
-		Scheme: "http",
-	}
-	if r.buildScheme != "" {
-		u.Scheme = r.buildScheme
-	}
-	return u, nil
-}
-
 // URLHost builds the host part of the URL for a route. See Route.URL().
 //
 // The route must have a host defined.


### PR DESCRIPTION
- Capture first scheme configured for a route for use when building URLs.
- Add new Route.URLScheme method similar to URLHost and URLPath.
- Update Route.URLHost and Route.URL to use the captured scheme if present.

Fixes #13. Supersedes #161. 