### PR TITLE
Update Walk to match all subrouters

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -299,10 +299,6 @@ type WalkFunc func(route *Route, router *Router, ancestors []*Route) error
 
 func (r *Router) walk(walkFn WalkFunc, ancestors []*Route) error {
 	for _, t := range r.routes {
-		if t.regexp == nil || t.regexp.path == nil || t.regexp.path.template == "" {
-			continue
-		}
-
 		err := walkFn(t, r, ancestors)
 		if err == SkipRouter {
 			continue

--- a/mux_test.go
+++ b/mux_test.go
@@ -1329,6 +1329,34 @@ func TestWalkNested(t *testing.T) {
 	}
 }
 
+func TestWalkSubrouters(t *testing.T) {
+	router := NewRouter()
+
+	g := router.Path("/g").Subrouter()
+	o := g.PathPrefix("/o").Subrouter()
+	o.Methods("GET")
+	o.Methods("PUT")
+
+	// all 4 routes should be matched, but final 2 routes do not have path templates
+	paths := []string{"/g", "/g/o", "", ""}
+	idx := 0
+	err := router.Walk(func(route *Route, router *Router, ancestors []*Route) error {
+		path := paths[idx]
+		tpl, _ := route.GetPathTemplate()
+		if tpl != path {
+			t.Errorf(`Expected %s got %s`, path, tpl)
+		}
+		idx++
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	if idx != len(paths) {
+		t.Errorf("Expected %d routes, found %d", len(paths), idx)
+	}
+}
+
 func TestWalkErrorRoute(t *testing.T) {
 	router := NewRouter()
 	router.Path("/g")


### PR DESCRIPTION
Matches all routes instead of just routes with paths.

Fixes #261