### PR TITLE
Removing half of conflict marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,6 @@ s.HandleFunc("/{key}/", ProductHandler)
 // "/products/{key}/details"
 s.HandleFunc("/{key}/details", ProductDetailsHandler)
 ```
-
-<<<<<<< f85983fbfd0e0146e24ba184acbdca25f0361e99
 ### Listing Routes
 
 Routes on a mux can be listed using the Router.Walk method—useful for generating documentation:


### PR DESCRIPTION
Looks like there was just part of a conflict marker in the README file, so I figured I'd remove it.