### PR TITLE
Fix invalid example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 func main() {
     r := mux.NewRouter()
     r.HandleFunc("/", handler)
-    r.Methods("POST").HandleFunc("/products", handler)
-    r.Methods("GET").HandleFunc("/articles", handler)
-    r.Methods("GET", "PUT").HandleFunc("/articles/{id}", handler)
+    r.HandleFunc("/products", handler).Methods("POST")
+    r.HandleFunc("/articles", handler).Methods("GET")
+    r.HandleFunc("/articles/{id}", handler).Methods("GET", "PUT")
     r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
         t, err := route.GetPathTemplate()
         if err != nil {

--- a/README.md
+++ b/README.md
@@ -326,9 +326,9 @@ the following prints all of the registered routes:
 ```go
 r := mux.NewRouter()
 r.HandleFunc("/", handler)
-r.Methods("POST").HandleFunc("/products", handler)
-r.Methods("GET").HandleFunc("/articles", handler)
-r.Methods("GET", "PUT").HandleFunc("/articles/{id}", handler)
+r.HandleFunc("/products", handler).Methods("POST")
+r.HandleFunc("/articles", handler).Methods("GET")
+r.HandleFunc("/articles/{id}", handler).Methods("GET", "PUT")
 r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
     t, err := route.GetPathTemplate()
     if err != nil {


### PR DESCRIPTION
In the "Listing Routes" example code, `.HandleFunc` was being called on a `*mux.Route` rather than `*mux.Router`. Updated the example code to work.