### PR TITLE
Add support for queries in URL reversing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The name mux stands for "HTTP request multiplexer". Like the standard `http.Serv
 
 * It implements the `http.Handler` interface so it is compatible with the standard `http.ServeMux`.
 * Requests can be matched based on URL host, path, path prefix, schemes, header and query values, HTTP methods or using custom matchers.
-* URL hosts and paths can have variables with an optional regular expression.
+* URL hosts, paths and query values can have variables with an optional regular expression.
 * Registered URLs can be built, or "reversed", which helps maintaining references to resources.
 * Routes can be used as subrouters: nested routes are only tested if the parent route matches. This is useful to define groups of routes that share common conditions like a host, a path prefix or other repeated attributes. As a bonus, this optimizes request matching.
 
@@ -268,19 +268,21 @@ url, err := r.Get("article").URL("category", "technology", "id", "42")
 "/articles/technology/42"
 ```
 
-This also works for host variables:
+This also works for host and query value variables:
 
 ```go
 r := mux.NewRouter()
 r.Host("{subdomain}.domain.com").
   Path("/articles/{category}/{id:[0-9]+}").
+  Queries("filter", "{filter}")
   HandlerFunc(ArticleHandler).
   Name("article")
 
-// url.String() will be "http://news.domain.com/articles/technology/42"
+// url.String() will be "http://news.domain.com/articles/technology/42?filter=gorilla"
 url, err := r.Get("article").URL("subdomain", "news",
                                  "category", "technology",
-                                 "id", "42")
+                                 "id", "42",
+                                 "filter", "gorilla")
 ```
 
 All variables defined in the route are required, and their values must conform to the corresponding patterns. These requirements guarantee that a generated URL will always match a registered route -- the only exception is for explicitly defined "build-only" routes which never match.

--- a/doc.go
+++ b/doc.go
@@ -12,8 +12,8 @@ or other conditions. The main features are:
 
 	* Requests can be matched based on URL host, path, path prefix, schemes,
 	  header and query values, HTTP methods or using custom matchers.
-	* URL hosts and paths can have variables with an optional regular
-	  expression.
+	* URL hosts, paths and query values can have variables with an optional
+	  regular expression.
 	* Registered URLs can be built, or "reversed", which helps maintaining
 	  references to resources.
 	* Routes can be used as subrouters: nested routes are only tested if the
@@ -188,18 +188,20 @@ key/value pairs for the route variables. For the previous route, we would do:
 
 	"/articles/technology/42"
 
-This also works for host variables:
+This also works for host and query value variables:
 
 	r := mux.NewRouter()
 	r.Host("{subdomain}.domain.com").
 	  Path("/articles/{category}/{id:[0-9]+}").
+	  Queries("filter", "{filter}").
 	  HandlerFunc(ArticleHandler).
 	  Name("article")
 
-	// url.String() will be "http://news.domain.com/articles/technology/42"
+	// url.String() will be "http://news.domain.com/articles/technology/42?filter=gorilla"
 	url, err := r.Get("article").URL("subdomain", "news",
 	                                 "category", "technology",
-	                                 "id", "42")
+	                                 "id", "42",
+	                                 "filter", "gorilla")
 
 All variables defined in the route are required, and their values must
 conform to the corresponding patterns. These requirements guarantee that a

--- a/mux_test.go
+++ b/mux_test.go
@@ -36,6 +36,7 @@ type routeTest struct {
 	scheme         string            // the expected scheme of the built URL
 	host           string            // the expected host of the built URL
 	path           string            // the expected path of the built URL
+	query          string            // the expected query string to match
 	pathTemplate   string            // the expected path template of the route
 	hostTemplate   string            // the expected host template of the route
 	methods        []string          // the expected route methods
@@ -744,6 +745,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{},
 			host:        "",
 			path:        "",
+			query:       "foo=bar&baz=ding",
 			shouldMatch: true,
 		},
 		{
@@ -753,6 +755,7 @@ func TestQueries(t *testing.T) {
 			vars:         map[string]string{},
 			host:         "",
 			path:         "",
+			query:        "foo=bar&baz=ding",
 			pathTemplate: `/api`,
 			hostTemplate: `www.example.com`,
 			shouldMatch:  true,
@@ -764,6 +767,7 @@ func TestQueries(t *testing.T) {
 			vars:         map[string]string{},
 			host:         "",
 			path:         "",
+			query:        "foo=bar&baz=ding",
 			pathTemplate: `/api`,
 			hostTemplate: `www.example.com`,
 			shouldMatch:  true,
@@ -784,6 +788,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v1": "bar"},
 			host:        "",
 			path:        "",
+			query:       "foo=bar",
 			shouldMatch: true,
 		},
 		{
@@ -793,6 +798,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v1": "bar", "v2": "ding"},
 			host:        "",
 			path:        "",
+			query:       "foo=bar&baz=ding",
 			shouldMatch: true,
 		},
 		{
@@ -802,6 +808,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v1": "10"},
 			host:        "",
 			path:        "",
+			query:       "foo=10",
 			shouldMatch: true,
 		},
 		{
@@ -820,6 +827,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v1": "1"},
 			host:        "",
 			path:        "",
+			query:       "foo=1",
 			shouldMatch: true,
 		},
 		{
@@ -829,6 +837,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v1": "1"},
 			host:        "",
 			path:        "",
+			query:       "foo=1",
 			shouldMatch: true,
 		},
 		{
@@ -847,6 +856,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v1": "1a"},
 			host:        "",
 			path:        "",
+			query:       "foo=1a",
 			shouldMatch: true,
 		},
 		{
@@ -865,6 +875,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v-1": "bar"},
 			host:        "",
 			path:        "",
+			query:       "foo=bar",
 			shouldMatch: true,
 		},
 		{
@@ -874,6 +885,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v-1": "bar", "v-2": "ding"},
 			host:        "",
 			path:        "",
+			query:       "foo=bar&baz=ding",
 			shouldMatch: true,
 		},
 		{
@@ -883,6 +895,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v-1": "10"},
 			host:        "",
 			path:        "",
+			query:       "foo=10",
 			shouldMatch: true,
 		},
 		{
@@ -892,6 +905,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"v-1": "1a"},
 			host:        "",
 			path:        "",
+			query:       "foo=1a",
 			shouldMatch: true,
 		},
 		{
@@ -901,6 +915,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{},
 			host:        "",
 			path:        "",
+			query:       "foo=",
 			shouldMatch: true,
 		},
 		{
@@ -919,6 +934,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{},
 			host:        "",
 			path:        "",
+			query:       "foo=",
 			shouldMatch: true,
 		},
 		{
@@ -946,6 +962,7 @@ func TestQueries(t *testing.T) {
 			vars:        map[string]string{"foo": ""},
 			host:        "",
 			path:        "",
+			query:       "foo=",
 			shouldMatch: true,
 		},
 		{
@@ -1537,6 +1554,7 @@ func testRoute(t *testing.T, test routeTest) {
 	route := test.route
 	vars := test.vars
 	shouldMatch := test.shouldMatch
+	query := test.query
 	shouldRedirect := test.shouldRedirect
 	uri := url.URL{
 		Scheme: test.scheme,
@@ -1603,6 +1621,13 @@ func testRoute(t *testing.T, test routeTest) {
 			}
 			if expected, got := uri.String(), u.String(); expected != got {
 				t.Errorf("(%v) URL not equal: expected %v, got %v -- %v", test.title, expected, got, getRouteTemplate(route))
+				return
+			}
+		}
+		if query != "" {
+			u, _ := route.URL(mapToPairs(match.Vars)...)
+			if query != u.RawQuery {
+				t.Errorf("(%v) URL query not equal: expected %v, got %v", test.title, query, u.RawQuery)
 				return
 			}
 		}

--- a/mux_test.go
+++ b/mux_test.go
@@ -36,7 +36,7 @@ type routeTest struct {
 	scheme         string            // the expected scheme of the built URL
 	host           string            // the expected host of the built URL
 	path           string            // the expected path of the built URL
-	query          string            // the expected query string to match
+	query          string            // the expected query string of the built URL
 	pathTemplate   string            // the expected path template of the route
 	hostTemplate   string            // the expected host template of the route
 	methods        []string          // the expected route methods
@@ -973,6 +973,16 @@ func TestQueries(t *testing.T) {
 			host:        "",
 			path:        "",
 			shouldMatch: false,
+		},
+		{
+			title:       "Queries route with pattern, match, escaped value",
+			route:       new(Route).Queries("foo", "{v1}"),
+			request:     newRequest("GET", "http://localhost?foo=%25bar%26%20%2F%3D%3F"),
+			vars:        map[string]string{"v1": "%bar& /=?"},
+			host:        "",
+			path:        "",
+			query:       "foo=%25bar%26+%2F%3D%3F",
+			shouldMatch: true,
 		},
 	}
 

--- a/regexp.go
+++ b/regexp.go
@@ -178,6 +178,9 @@ func (r *routeRegexp) url(values map[string]string) (string, error) {
 		if !ok {
 			return "", fmt.Errorf("mux: missing route variable %q", v)
 		}
+		if r.matchQuery {
+			value = url.QueryEscape(value)
+		}
 		urlValues[k] = value
 	}
 	rv := fmt.Sprintf(r.reverse, urlValues...)

--- a/regexp.go
+++ b/regexp.go
@@ -35,7 +35,7 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash,
 	// Now let's parse it.
 	defaultPattern := "[^/]+"
 	if matchQuery {
-		defaultPattern = "[^?&]*"
+		defaultPattern = ".*"
 	} else if matchHost {
 		defaultPattern = "[^.]+"
 		matchPrefix = false

--- a/route.go
+++ b/route.go
@@ -482,6 +482,7 @@ func (r *Route) URL(pairs ...string) (*url.URL, error) {
 		return nil, err
 	}
 	var scheme, host, path string
+	queries := make([]string, 0, len(r.regexp.queries))
 	if r.regexp.host != nil {
 		if host, err = r.regexp.host.url(values); err != nil {
 			return nil, err
@@ -496,10 +497,18 @@ func (r *Route) URL(pairs ...string) (*url.URL, error) {
 			return nil, err
 		}
 	}
+	for _, q := range r.regexp.queries {
+		var query string
+		if query, err = q.url(values); err != nil {
+			return nil, err
+		}
+		queries = append(queries, query)
+	}
 	return &url.URL{
-		Scheme: scheme,
-		Host:   host,
-		Path:   path,
+		Scheme:   scheme,
+		Host:     host,
+		Path:     path,
+		RawQuery: strings.Join(queries, "&"),
 	}, nil
 }
 


### PR DESCRIPTION
This PR builds on and supersedes #230. It fixes #238 and #255.

* Rebased the two commits by @pamburus from #230 and resolved the conflicts.
* Updated README.md and the godocs to reflect the new functionality.
* Added a test for escaped query values, which duplicated #238.
* Added a fix for #238. The fix for that—changing the default pattern for query values from `[^?&]*` to `.*`—is safe because the Go standard library has already removed the semantically important `?` and `&` characters from the query string when parsing it into individual key/value pairs. The matching logic in `routeRegexp.matchQueryString` uses the regex to match already parsed and decoded query values returned by `routeRegexp.getURLQuery`.