### PR TITLE
Add route priority

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"path"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -333,6 +334,17 @@ func (r *Router) walk(walkFn WalkFunc, ancestors []*Route) error {
 		}
 	}
 	return nil
+}
+
+type routes []*Route
+
+func (r routes) Len() int           { return len(r) }
+func (r routes) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+func (r routes) Less(i, j int) bool { return r[i].GetPriority() > r[j].GetPriority() }
+
+// SortRoutes sort routes by route priority
+func (r *Router) SortRoutes() {
+	sort.Sort(routes(r.routes))
 }
 
 // ----------------------------------------------------------------------------

--- a/route.go
+++ b/route.go
@@ -39,6 +39,8 @@ type Route struct {
 	name string
 	// Error resulted from building a route.
 	err error
+	// Priority of this route
+	priority int
 
 	buildVarsFunc BuildVarsFunc
 }
@@ -129,6 +131,19 @@ func (r *Route) Name(name string) *Route {
 // GetName returns the name for the route, if any.
 func (r *Route) GetName() string {
 	return r.name
+}
+
+// Priority -----------------------------------------------------------------------
+
+// Priority sets the priority for the route
+func (r *Route) Priority(priority int) *Route {
+	r.priority = priority
+	return r
+}
+
+// GetPriority returns the priority for the route.
+func (r *Route) GetPriority() int {
+	return r.priority
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds the concept of priorities to routes.
We use gorilla/mux quite intensively on [Traefik](https://github.com/containous/traefik) and we had to add this concept to mux in order to sort routes with a specific order in the muxer.
It allows us to catch `http://mydomain.com/bigpath` before `http://mydomain.com/big` for example.
Let me know if you are not interested in this feature, I will close the PR then :)

Signed-off-by: Emile Vauge <emile@vauge.com>