### PR TITLE
Clear up confusion around StrictSlash

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -163,6 +163,19 @@ func (r *Router) StrictSlash(value bool) *Router {
 	return r
 }
 
+// StrictRouting serves as a clearer version of StrictSlash. It does the
+// the opposite of StrictSlash.
+//
+// When true, if the route path is "/path", accessing "/path/" will not much
+// this route and vice verse.
+//
+// When false, if the route path is "/path", accessing "/path" will redirect
+// to the former and vice verse. In other words, your application will always
+// see the path as specified in the route.
+func (r *Router) StrictRouting(value bool) *Router {
+	return r.StrictSlash(!value)
+}
+
 // SkipClean defines the path cleaning behaviour for new routes. The initial
 // value is false. Users should be careful about which routes are not cleaned
 //

--- a/mux_test.go
+++ b/mux_test.go
@@ -1343,6 +1343,80 @@ func TestStrictSlash(t *testing.T) {
 	}
 }
 
+func TestStrictRouting(t *testing.T) {
+	r := NewRouter()
+	r.StrictRouting(false)
+
+	tests := []routeTest{
+		{
+			title:          "Redirect path without slash",
+			route:          r.NewRoute().Path("/111/"),
+			request:        newRequest("GET", "http://localhost/111"),
+			vars:           map[string]string{},
+			host:           "",
+			path:           "/111/",
+			shouldMatch:    true,
+			shouldRedirect: true,
+		},
+		{
+			title:          "Do not redirect path with slash",
+			route:          r.NewRoute().Path("/111/"),
+			request:        newRequest("GET", "http://localhost/111/"),
+			vars:           map[string]string{},
+			host:           "",
+			path:           "/111/",
+			shouldMatch:    true,
+			shouldRedirect: false,
+		},
+		{
+			title:          "Redirect path with slash",
+			route:          r.NewRoute().Path("/111"),
+			request:        newRequest("GET", "http://localhost/111/"),
+			vars:           map[string]string{},
+			host:           "",
+			path:           "/111",
+			shouldMatch:    true,
+			shouldRedirect: true,
+		},
+		{
+			title:          "Do not redirect path without slash",
+			route:          r.NewRoute().Path("/111"),
+			request:        newRequest("GET", "http://localhost/111"),
+			vars:           map[string]string{},
+			host:           "",
+			path:           "/111",
+			shouldMatch:    true,
+			shouldRedirect: false,
+		},
+		{
+			title:          "Propagate StrictRouting to subrouters",
+			route:          r.NewRoute().PathPrefix("/static/").Subrouter().Path("/images/"),
+			request:        newRequest("GET", "http://localhost/static/images"),
+			vars:           map[string]string{},
+			host:           "",
+			path:           "/static/images/",
+			shouldMatch:    true,
+			shouldRedirect: true,
+		},
+		{
+			title:          "Ignore StrictRouting for path prefix",
+			route:          r.NewRoute().PathPrefix("/static/"),
+			request:        newRequest("GET", "http://localhost/static/logo.png"),
+			vars:           map[string]string{},
+			host:           "",
+			path:           "/static/",
+			shouldMatch:    true,
+			shouldRedirect: false,
+		},
+	}
+
+	for _, test := range tests {
+		testRoute(t, test)
+		testTemplate(t, test)
+		testUseEscapedRoute(t, test)
+	}
+}
+
 func TestUseEncodedPath(t *testing.T) {
 	r := NewRouter()
 	r.UseEncodedPath()


### PR DESCRIPTION
Fixes #145.

I've kept the StrictSlash function for backwards compatibility. The StrictRouting function is only there to serve as a clearer way to impose a strict slash.
It does the opposite of StrictSlash.