### PR TITLE
[docs] Add example usage for Route.HeadersRegexp

### DIFF
--- a/example_route_test.go
+++ b/example_route_test.go
@@ -13,15 +13,15 @@ import (
 func ExampleRoute_HeadersRegexp() {
 	r := mux.NewRouter()
 	route := r.NewRoute().HeadersRegexp("Accept", "html")
-	matchInfo := &mux.RouteMatch{}
-	req1, _ := http.NewRequest("GET", "example.com", nil)
-	req2, _ := http.NewRequest("GET", "example.com", nil)
 
+	req1, _ := http.NewRequest("GET", "example.com", nil)
 	req1.Header.Add("Accept", "text/plain")
 	req1.Header.Add("Accept", "text/html")
 
+	req2, _ := http.NewRequest("GET", "example.com", nil)
 	req2.Header.Set("Accept", "application/xhtml+xml")
 
+	matchInfo := &mux.RouteMatch{}
 	fmt.Printf("Match: %v %q\n", route.Match(req1, matchInfo), req1.Header["Accept"])
 	fmt.Printf("Match: %v %q\n", route.Match(req2, matchInfo), req2.Header["Accept"])
 	// Output:
@@ -35,14 +35,14 @@ func ExampleRoute_HeadersRegexp() {
 func ExampleRoute_HeadersRegexp_exactMatch() {
 	r := mux.NewRouter()
 	route := r.NewRoute().HeadersRegexp("Origin", "^https://example.co$")
-	matchInfo := &mux.RouteMatch{}
-	yes, _ := http.NewRequest("GET", "example.co", nil)
-	no, _ := http.NewRequest("GET", "example.co.uk", nil)
 
+	yes, _ := http.NewRequest("GET", "example.co", nil)
 	yes.Header.Set("Origin", "https://example.co")
 
+	no, _ := http.NewRequest("GET", "example.co.uk", nil)
 	no.Header.Set("Origin", "https://example.co.uk")
 
+	matchInfo := &mux.RouteMatch{}
 	fmt.Printf("Match: %v %q\n", route.Match(yes, matchInfo), yes.Header["Origin"])
 	fmt.Printf("Match: %v %q\n", route.Match(no, matchInfo), no.Header["Origin"])
 	// Output:

--- a/example_route_test.go
+++ b/example_route_test.go
@@ -1,0 +1,51 @@
+package mux_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// This example demonstrates setting a regular expression matcher for
+// the header value. A plain word will match any value that contains a
+// matching substring as if the pattern was wrapped with `.*`.
+func ExampleRoute_HeadersRegexp() {
+	r := mux.NewRouter()
+	route := r.NewRoute().HeadersRegexp("Accept", "html")
+	matchInfo := &mux.RouteMatch{}
+	req1, _ := http.NewRequest("GET", "example.com", nil)
+	req2, _ := http.NewRequest("GET", "example.com", nil)
+
+	req1.Header.Add("Accept", "text/plain")
+	req1.Header.Add("Accept", "text/html")
+
+	req2.Header.Set("Accept", "application/xhtml+xml")
+
+	fmt.Printf("Match: %v %q\n", route.Match(req1, matchInfo), req1.Header["Accept"])
+	fmt.Printf("Match: %v %q\n", route.Match(req2, matchInfo), req2.Header["Accept"])
+	// Output:
+	// Match: true ["text/plain" "text/html"]
+	// Match: true ["application/xhtml+xml"]
+}
+
+// This example demonstrates setting a strict regular expression matcher
+// for the header value. Using the start and end of string anchors, the
+// value must be an exact match.
+func ExampleRoute_HeadersRegexp_exactMatch() {
+	r := mux.NewRouter()
+	route := r.NewRoute().HeadersRegexp("Origin", "^https://example.co$")
+	matchInfo := &mux.RouteMatch{}
+	yes, _ := http.NewRequest("GET", "example.co", nil)
+	no, _ := http.NewRequest("GET", "example.co.uk", nil)
+
+	yes.Header.Set("Origin", "https://example.co")
+
+	no.Header.Set("Origin", "https://example.co.uk")
+
+	fmt.Printf("Match: %v %q\n", route.Match(yes, matchInfo), yes.Header["Origin"])
+	fmt.Printf("Match: %v %q\n", route.Match(no, matchInfo), no.Header["Origin"])
+	// Output:
+	// Match: true ["https://example.co"]
+	// Match: false ["https://example.co.uk"]
+}

--- a/route.go
+++ b/route.go
@@ -258,7 +258,8 @@ func (m headerRegexMatcher) Match(r *http.Request, match *RouteMatch) bool {
 //               "X-Requested-With", "XMLHttpRequest")
 //
 // The above route will only match if both the request header matches both regular expressions.
-// It the value is an empty string, it will match any value if the key is set.
+// If the value is an empty string, it will match any value if the key is set.
+// Use the start and end of string anchors (^ and $) to match an exact value.
 func (r *Route) HeadersRegexp(pairs ...string) *Route {
 	if r.err == nil {
 		var headers map[string]*regexp.Regexp


### PR DESCRIPTION
Implements the documentation aspect of #124.

Updates the documentation comment header for `route.go:Route.HeadersRegexp`. And also adds `example_route_test.go` containing:  
1. `ExampleRoute_HeadersRegexp`. Demonstrates the wildcard behavior of Go's `regexp.Compile`.
2. `ExampleRoute_HeadersRegexp_exactMatch`. Demonstrates strict matching using start and end of string anchors.