### PR TITLE
[docs] Note StrictSlash re-direct behaviour #308

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -164,7 +164,7 @@ func (r *Router) GetRoute(name string) *Route {
 // StrictSlash defines the trailing slash behavior for new routes. The initial
 // value is false.
 //
-// When true, if the route path is "/path/", accessing "/path" will perform a  redirect
+// When true, if the route path is "/path/", accessing "/path" will perform a redirect
 // to the former and vice versa. In other words, your application will always
 // see the path as specified in the route.
 //
@@ -173,8 +173,8 @@ func (r *Router) GetRoute(name string) *Route {
 //
 // The re-direct is a HTTP 301 (Moved Permanently). Note that when this is set for
 // routes with a non-idempotent method (e.g. POST, PUT), the subsequent re-directed
-// request will be made as a GET by clients. Use middleware to modify this behaviour
-// as needed.
+// request will be made as a GET by most clients. Use middleware or client settings
+// to modify this behaviour as needed.
 //
 // Special case: when a route sets a path prefix using the PathPrefix() method,
 // strict slash is ignored for that route because the redirect behavior can't

--- a/mux.go
+++ b/mux.go
@@ -164,12 +164,17 @@ func (r *Router) GetRoute(name string) *Route {
 // StrictSlash defines the trailing slash behavior for new routes. The initial
 // value is false.
 //
-// When true, if the route path is "/path/", accessing "/path" will redirect
+// When true, if the route path is "/path/", accessing "/path" will perform a  redirect
 // to the former and vice versa. In other words, your application will always
 // see the path as specified in the route.
 //
 // When false, if the route path is "/path", accessing "/path/" will not match
 // this route and vice versa.
+//
+// The re-direct is a HTTP 301 (Moved Permanently). Note that when this is set for
+// routes with a non-idempotent method (e.g. POST, PUT), the subsequent re-directed
+// request will be made as a GET by clients. Use middleware to modify this behaviour
+// as needed.
 //
 // Special case: when a route sets a path prefix using the PathPrefix() method,
 // strict slash is ignored for that route because the redirect behavior can't


### PR DESCRIPTION
* StrictSlash enabled routes return a 301 to the client
* As per the HTTP standards, non-idempotent methods, such as POST or PUT, will be followed with a GET by the client
* Users should use middleware if they wish to change this behaviour to return a HTTP 308.

Addresses https://github.com/gorilla/mux/issues/308