### PR TITLE
Public test API to set URL params

### DIFF
--- a/test_helpers.go
+++ b/test_helpers.go
@@ -6,11 +6,13 @@ package mux
 
 import "net/http"
 
-// SetURLVars sets URL variables. This can be used to simplify the testing of
-// request handlers.
-// Alternatively, URL variables can be set by making a route that captures the
-// required variables, starting a server and sending the request to that
-// server.
+// SetURLVars sets the URL variables for the given request, to be accessed via
+// mux.Vars for testing route behaviour.
+//
+// This API should only be used for testing purposes; it provides a way to
+// inject variables into the request context. Alternatively, URL variables
+// can be set by making a route that captures the required variables,
+// starting a server and sending the request to that server.
 func SetURLVars(r *http.Request, val map[string]string) *http.Request {
 	return setVars(r, val)
 }

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -1,0 +1,16 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mux
+
+import "net/http"
+
+// SetURLVars sets URL variables. This can be used to simplify the testing of
+// request handlers.
+// Alternatively, URL variables can be set by making a route that captures the
+// required variables, starting a server and sending the request to that
+// server.
+func SetURLVars(r *http.Request, val map[string]string) *http.Request {
+	return setVars(r, val)
+}

--- a/testing.go
+++ b/testing.go
@@ -1,0 +1,8 @@
+package mux
+
+import "net/http"
+
+// TestSetURLParam set url params
+func TestSetURLParam(r *http.Request, val map[string]string) *http.Request {
+	return setVars(r, val)
+}

--- a/testing.go
+++ b/testing.go
@@ -1,8 +1,0 @@
-package mux
-
-import "net/http"
-
-// TestSetURLParam set url params
-func TestSetURLParam(r *http.Request, val map[string]string) *http.Request {
-	return setVars(r, val)
-}


### PR DESCRIPTION
As discussed in #233, it will be useful to have a test focused API to set URL params. Currently this is not possible because the route key type used to store the vars in the context is private and the setVars function is also private.

Currently there are two work arounds to address this, the first being to make pull the vars extraction up in to the middleware layer, which requires a significant refactor and the other is to spin up a server and running the request through a route to populate the context with the vars. The problem with this is that it's very heavy handed and for those running tests in hosted CI environments like travis, the extra bloat can slow down test execution potentially to the point where testing handlers no longer becomes viable.

This should allow for the testing of routes and route handlers to be done separately while also preserving the current level of indirection that has allowed for the underlying context implementation to be changed (as seen in this [PR](https://github.com/gorilla/mux/pull/169)).

The added public API end point is prefixed with "Test" and can be found in `testing.go` to emphasise that this is a utility specifically meant for testing rather than in normal program flow. This notion of testing as a public API is borrowed from this slide [Advanced Testing with Go](https://speakerdeck.com/mitchellh/advanced-testing-with-go?slide=53).

