### PR TITLE
[docs] Clarify SetURLVars

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -2248,6 +2248,15 @@ func TestMethodsSubrouterPathVariable(t *testing.T) {
 	}
 }
 
+func ExampleSetURLVars() {
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	req = SetURLVars(req, map[string]string{"foo": "bar"})
+
+	fmt.Println(Vars(req)["foo"])
+
+	// Output: bar
+}
+
 // testMethodsSubrouter runs an individual methodsSubrouterTest.
 func testMethodsSubrouter(t *testing.T, test methodsSubrouterTest) {
 	// Execute request

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -7,12 +7,8 @@ package mux
 import "net/http"
 
 // SetURLVars sets the URL variables for the given request, to be accessed via
-// mux.Vars for testing route behaviour. A shallow copy of the *http.Request is
-// returned, the given *http.Request is not modified, so you will need to set
-// the request to the returned *http.Request like so:
-//
-//     req, _ := http.NewRequest("GET", "/foo", nil)
-//     req = mux.SetURLVars(req, map[string]string{"foo": "bar"})
+// mux.Vars for testing route behaviour. Arguments are not modified, a shallow
+// copy is returned.
 //
 // This API should only be used for testing purposes; it provides a way to
 // inject variables into the request context. Alternatively, URL variables

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -7,7 +7,12 @@ package mux
 import "net/http"
 
 // SetURLVars sets the URL variables for the given request, to be accessed via
-// mux.Vars for testing route behaviour.
+// mux.Vars for testing route behaviour. A shallow copy of the *http.Request is
+// returned, the given *http.Request is not modified, so you will need to set
+// the request to the returned *http.Request like so:
+//
+//     req, _ := http.NewRequest("GET", "/foo", nil)
+//     req = mux.SetURLVars(req, map[string]string{"foo": "bar"})
 //
 // This API should only be used for testing purposes; it provides a way to
 // inject variables into the request context. Alternatively, URL variables


### PR DESCRIPTION
Clarify in documentation that SetURLVars does not modify the given *htttp.Request, provide an example of usage.

Addresses #334 