### PR TITLE
Router.ServeHTTP(): fixed redirect issues if url.host/scheme/user are non-empty

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -129,6 +129,14 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			// http://code.google.com/p/go/issues/detail?id=5252
 			url := *req.URL
 			url.Path = p
+
+			// clean up URL (in case it's been modified for some reason)
+			// If there was a .User for example, url.String() would return user@/path,
+			// breaking the redirect
+			url.Schema = ""
+			url.Host = ""
+			url.User = nil
+
 			p = url.String()
 
 			w.Header().Set("Location", p)

--- a/mux.go
+++ b/mux.go
@@ -130,12 +130,13 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			url := *req.URL
 			url.Path = p
 
-			// clean up URL (in case it's been modified for some reason)
-			// If there was a .User for example, url.String() would return user@/path,
-			// breaking the redirect
-			url.Schema = ""
-			url.Host = ""
-			url.User = nil
+			if url.Host == "" {
+				// clean up non-absolute URLs (in case it's been modified, e.g. to have the username in the logs - see PR #341)
+				// If there was a .User for example, url.String() would return `//user@/path/to/file`,
+				// breaking the HTTP location header
+				url.Scheme = ""
+				url.User = nil
+			}
 
 			p = url.String()
 


### PR DESCRIPTION
I'm using your `handlers.CombinedLoggingHandler` for logging.  
To log the request user, I set `req.URL.User = url.User(...)` in a wrapper before invoking the logging handler.

This works fine for logging, but breaks `mux.StrictSlash(true)`.

Instead of redirecting to `/target/path`, it redirects to `user@/target/path`.

This PR fixes that by setting the Host, Schema and User fields (=> everything before the Path) of the `req.URL` copy to their `nil` values.