### PR TITLE
Expose ordered route param variable names

### DIFF
--- a/route.go
+++ b/route.go
@@ -618,6 +618,22 @@ func (r *Route) GetPathRegexp() (string, error) {
 	return r.regexp.path.regexp.String(), nil
 }
 
+// GetVarNames returns the route path variable names.
+// An error will be returned if the route does not define a path.
+func (r *Route) GetVarNames() ([]string, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.regexp == nil || r.regexp.path == nil {
+		return nil, errors.New("mux: route does not have a path")
+	}
+	var varsN []string
+	for _, varN := range r.regexp.path.varsN {
+		varsN = append(varsN, varN)
+	}
+	return varsN, nil
+}
+
 // GetQueriesRegexp returns the expanded regular expressions used to match the
 // route queries.
 // This is useful for building simple REST API documentation and for instrumentation


### PR DESCRIPTION
This PR exposes an ordered list of route param variable names. Existing APIs return insufficient information to determine the order of vars in a path: mux.Vars() returns an unordered map, GetPathTemplate() returns an unparsed path template string. 
