### PR TITLE
Modify 403 status code to const variable

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -287,7 +287,7 @@ A more complex authentication middleware, which maps session token to users, cou
 				log.Printf("Authenticated user %s\n", user)
 				next.ServeHTTP(w, r)
 			} else {
-				http.Error(w, "Forbidden", 403)
+				http.Error(w, "Forbidden", http.StatusForbidden)
 			}
 		})
 	}

--- a/example_authentication_middleware_test.go
+++ b/example_authentication_middleware_test.go
@@ -30,7 +30,7 @@ func (amw *authenticationMiddleware) Middleware(next http.Handler) http.Handler 
 			log.Printf("Authenticated user %s\n", user)
 			next.ServeHTTP(w, r)
 		} else {
-			http.Error(w, "Forbidden", 403)
+			http.Error(w, "Forbidden", http.StatusForbidden)
 		}
 	})
 }


### PR DESCRIPTION
Go provides HTTP status codes as  const variables.