### PR TITLE
Make Use() variadic

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -18,8 +18,10 @@ func (mw MiddlewareFunc) Middleware(handler http.Handler) http.Handler {
 }
 
 // Use appends a MiddlewareFunc to the chain. Middleware can be used to intercept or otherwise modify requests and/or responses, and are executed in the order that they are applied to the Router.
-func (r *Router) Use(mwf MiddlewareFunc) {
-	r.middlewares = append(r.middlewares, mwf)
+func (r *Router) Use(mwf ...MiddlewareFunc) {
+	for _, fn := range mwf {
+		r.middlewares = append(r.middlewares, fn)
+	}
 }
 
 // useInterface appends a middleware to the chain. Middleware can be used to intercept or otherwise modify requests and/or responses, and are executed in the order that they are applied to the Router.


### PR DESCRIPTION
Enables neater syntax when chaining several middleware functions:

``` go
router.Use(mwFunc1, mwFunc2, mwfunc3)
```

Fully backwards-compatible when using a single function as argument.