### PR TITLE
Add two methods to easily get body values to map

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -5,6 +5,7 @@
 package mux
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -410,6 +411,30 @@ func Vars(r *http.Request) map[string]string {
 		return rv.(map[string]string)
 	}
 	return nil
+}
+
+// ValuesAny returns Body variables for the current request, if any.
+func ValuesAny(r *http.Request) (map[string]interface{}, error) {
+	var body map[string]interface{}
+	err := json.NewDecoder(r.Body).Decode(body)
+
+	if err != nil {
+		return body, nil
+	}
+
+	return nil, nil
+}
+
+// ValuesString returns Body variables for the current request, if any.
+func ValuesString(r *http.Request) (map[string]string, error) {
+	var body map[string]string
+	err := json.NewDecoder(r.Body).Decode(body)
+
+	if err != nil {
+		return body, nil
+	}
+
+	return nil, nil
 }
 
 // CurrentRoute returns the matched route for the current request, if any.

--- a/mux.go
+++ b/mux.go
@@ -413,8 +413,8 @@ func Vars(r *http.Request) map[string]string {
 	return nil
 }
 
-// ValuesAny returns Body variables for the current request, if any.
-func ValuesAny(r *http.Request) (map[string]interface{}, error) {
+// AnyValues returns Body variables for the current request, if any. dev @okabbas
+func AnyValues(r *http.Request) (map[string]interface{}, error) {
 	var body map[string]interface{}
 	err := json.NewDecoder(r.Body).Decode(body)
 
@@ -425,8 +425,8 @@ func ValuesAny(r *http.Request) (map[string]interface{}, error) {
 	return nil, nil
 }
 
-// ValuesString returns Body variables for the current request, if any.
-func ValuesString(r *http.Request) (map[string]string, error) {
+// StringValues returns Body variables for the current request, if any. dev @okabbas
+func StringValues(r *http.Request) (map[string]string, error) {
 	var body map[string]string
 	err := json.NewDecoder(r.Body).Decode(body)
 


### PR DESCRIPTION
Hello . In normal mode, we can get variables using PostFormValue, but with these two methods, the values are injected internally into the map, and we can use the map outside of the http access.

It is also very painful to the database and it's much better than PostFormValue.

These two methods are very practical and make it a lot of work for me and prevent long lines of extra code.