### PR TITLE
Ensure that router middleware is always run

### DIFF
--- a/middleware_test.go
+++ b/middleware_test.go
@@ -136,6 +136,23 @@ func TestMiddlewareSubrouter(t *testing.T) {
 	}
 }
 
+func TestMiddlewareDuplicateSubrouter(t *testing.T) {
+	router := NewRouter()
+	router.PathPrefix("/sub").Subrouter() // Deliberately create a duplicate router
+	subrouter := router.PathPrefix("/sub").Subrouter()
+	subrouter.HandleFunc("/x", dummyHandler).Methods("GET")
+
+	mw := &testMiddleware{}
+	subrouter.useInterface(mw)
+
+	rw := NewRecorder()
+	req := newRequest("GET", "/sub/x")
+	router.ServeHTTP(rw, req)
+	if mw.timesCalled != 1 {
+		t.Fatalf("Expected %d calls, but got only %d", 1, mw.timesCalled)
+	}
+}
+
 func TestMiddlewareExecution(t *testing.T) {
 	mwStr := []byte("Middleware\n")
 	handlerStr := []byte("Logic\n")

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -136,36 +136,17 @@ func TestMiddlewareSubrouter(t *testing.T) {
 	}
 }
 
-func TestMiddlewareWithOverlappingSubrouter(t *testing.T) {
+func TestMiddlewareWithOverlappingSubrouterAndHandler(t *testing.T) {
 	router := NewRouter()
-	// Ensure that an overlapping router doesn't interfere with running of the middleware
-	router.PathPrefix("/sub/x").Subrouter()
-	subrouter := router.PathPrefix("/sub").Subrouter()
-	subrouter.HandleFunc("/x/y", dummyHandler).Methods("GET")
+	// Ensure that an overlapping subrouter doesn't interfere with running of the middleware on the parent route
+	router.PathPrefix("/x").Subrouter()
+	router.HandleFunc("/x", dummyHandler).Methods("GET")
 
 	mw := &testMiddleware{}
-	subrouter.useInterface(mw)
+	router.useInterface(mw)
 
 	rw := NewRecorder()
-	req := newRequest("GET", "/sub/x/y")
-	router.ServeHTTP(rw, req)
-	if mw.timesCalled != 1 {
-		t.Fatalf("Expected %d calls, but got only %d", 1, mw.timesCalled)
-	}
-}
-
-func TestMiddlewareDuplicateSubrouter(t *testing.T) {
-	router := NewRouter()
-	// Ensure that an duplicate router doesn't interfere with running of the middleware
-	router.PathPrefix("/sub").Subrouter()
-	subrouter := router.PathPrefix("/sub").Subrouter()
-	subrouter.HandleFunc("/x", dummyHandler).Methods("GET")
-
-	mw := &testMiddleware{}
-	subrouter.useInterface(mw)
-
-	rw := NewRecorder()
-	req := newRequest("GET", "/sub/x")
+	req := newRequest("GET", "/x")
 	router.ServeHTTP(rw, req)
 	if mw.timesCalled != 1 {
 		t.Fatalf("Expected %d calls, but got only %d", 1, mw.timesCalled)

--- a/mux_test.go
+++ b/mux_test.go
@@ -1994,7 +1994,7 @@ func TestMethodsSubrouterCatchall(t *testing.T) {
 	t.Parallel()
 
 	router := NewRouter()
-	router.Methods("PATCH").Subrouter().PathPrefix("/").HandlerFunc(methodHandler("PUT"))
+	router.Methods("PATCH").Subrouter().PathPrefix("/").HandlerFunc(methodHandler("PATCH"))
 	router.Methods("GET").Subrouter().HandleFunc("/foo", methodHandler("GET"))
 	router.Methods("POST").Subrouter().HandleFunc("/foo", methodHandler("POST"))
 	router.Methods("DELETE").Subrouter().HandleFunc("/foo", methodHandler("DELETE"))

--- a/route.go
+++ b/route.go
@@ -71,7 +71,7 @@ func (r *Route) Match(req *http.Request, match *RouteMatch) bool {
 
 	// Return a method mismatch error if we saw a method mismatch and everything else matched
 	if matchErr != nil {
-		// Wipe everything we may have recorded from a previous successful match with the wrong method
+		// A previous successful match with the wrong method would have overwritten this, so we must reset it here
 		*match = RouteMatch{MatchErr: matchErr}
 		return false
 	}


### PR DESCRIPTION
When a previous router matches with an error, middleware is not applied to handlers for later routers.  I was able to construct a test case where I could run a handler but the middleware for its router was not run.  There are some cases where we don't run middleware -- specifically for NotFound and MethodMismatch errors-- but I believe we should always be running the middleware for a normal handler.

I've added a test case for the issue I that led to this pull request:

```
	router := NewRouter()
	router.PathPrefix("/sub").Subrouter() // Deliberately create a duplicate router
	subrouter := router.PathPrefix("/sub").Subrouter()
	subrouter.HandleFunc("/x", dummyHandler).Methods("GET")

	mw := &testMiddleware{}
	subrouter.useInterface(mw)
```

In the example above, GET `/sub/x` does not trigger the middleware.

This PR also removes some code that I believe no longer has any effect with my changes.

I'm a bit concerned about who owns which fields in the `Match` structure.  It's not completely clear to me who gets to populate which fields when, so I hope it's ok for me to just clobber it.

There is a lot of complexity in here around handing wrong method errors.  My understanding of the general principle behind unexpected methods methods is that we want to use wrong method handlers, or to report wrong method only as a last resort, after we've tried to match everything else.  If I've misunderstood this, please let me the expected behavior and I can make some adjustments.
