### PR TITLE
Fix double OPTIONS allowed method in CORSMethodMiddleware

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -48,6 +48,10 @@ func CORSMethodMiddleware(r *Router) MiddlewareFunc {
 					if _, ok := m.(*routeRegexp); ok {
 						if m.Match(req, &RouteMatch{}) {
 							methods, err := route.GetMethods()
+							if err == ErrRouteHasNoMethods {
+								allMethods = []string{"OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "CONNECT"}
+								return nil
+							}
 							if err != nil {
 								return err
 							}

--- a/middleware.go
+++ b/middleware.go
@@ -33,9 +33,11 @@ func (r *Router) useInterface(mw middleware) {
 }
 
 // CORSMethodMiddleware sets the Access-Control-Allow-Methods response header
-// on a request, by matching routes based only on paths. It also handles
-// OPTIONS requests, by settings Access-Control-Allow-Methods, and then
-// returning without calling the next http handler.
+// on a request, by matching routes based only on paths.
+//
+// If a route in the router is set to handle OPTIONS calls, this middleware will
+// respond to OPTIONS calls with HTTP code "200 OK", the
+// Access-Control-Allow-Methods header and an empty body.
 func CORSMethodMiddleware(r *Router) MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/middleware.go
+++ b/middleware.go
@@ -48,10 +48,6 @@ func CORSMethodMiddleware(r *Router) MiddlewareFunc {
 					if _, ok := m.(*routeRegexp); ok {
 						if m.Match(req, &RouteMatch{}) {
 							methods, err := route.GetMethods()
-							if err == ErrRouteHasNoMethods {
-								allMethods = []string{"OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "CONNECT"}
-								return nil
-							}
 							if err != nil {
 								return err
 							}

--- a/middleware.go
+++ b/middleware.go
@@ -61,7 +61,7 @@ func CORSMethodMiddleware(r *Router) MiddlewareFunc {
 			})
 
 			if err == nil {
-				w.Header().Set("Access-Control-Allow-Methods", strings.Join(append(allMethods, "OPTIONS"), ","))
+				w.Header().Set("Access-Control-Allow-Methods", strings.Join(allMethods, ","))
 
 				if req.Method == "OPTIONS" {
 					return

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -378,6 +378,84 @@ func TestCORSMethodMiddleware(t *testing.T) {
 	}
 }
 
+func TestCORSMiddlewareOPTIONS(t *testing.T) {
+	t.Run("Without method matcher", func(t *testing.T) {
+		router := NewRouter()
+
+		cases := []struct {
+			path                   string
+			response               string
+			testURL                string
+			expectedAllowedMethods string
+		}{
+			{"/g/{o}", "a", "/g/asdf", "OPTIONS,GET,HEAD,POST,PUT,DELETE,TRACE,CONNECT"},
+		}
+
+		for _, tt := range cases {
+			router.HandleFunc(tt.path, stringHandler(tt.response))
+		}
+
+		router.Use(CORSMethodMiddleware(router))
+
+		for _, tt := range cases {
+			rr := httptest.NewRecorder()
+			req := newRequest("OPTIONS", tt.testURL)
+
+			router.ServeHTTP(rr, req)
+
+			allowedMethods := rr.HeaderMap.Get("Access-Control-Allow-Methods")
+
+			if want, have := 200, rr.Result().StatusCode; have != want {
+				t.Errorf("Expected status code %d, found %d", want, have)
+			}
+
+			if allowedMethods != tt.expectedAllowedMethods {
+				t.Errorf("Expected Access-Control-Allow-Methods '%s', found '%s'", tt.expectedAllowedMethods, allowedMethods)
+			}
+		}
+	})
+
+	t.Run("With method matcher", func(t *testing.T) {
+		router := NewRouter()
+
+		cases := []struct {
+			path                   string
+			response               string
+			method                 string
+			testURL                string
+			expectedAllowedMethods string
+		}{
+			{"/g/{o}", "a", "POST", "/g/asdf", "POST,PUT,GET,OPTIONS"},
+			{"/g/{o}", "b", "PUT", "/g/bla", "POST,PUT,GET,OPTIONS"},
+			{"/g/{o}", "c", "GET", "/g/orilla", "POST,PUT,GET,OPTIONS"},
+			{"/g/{o}", "c", "OPTIONS", "/g/orilla", "POST,PUT,GET,OPTIONS"},
+		}
+
+		for _, tt := range cases {
+			router.HandleFunc(tt.path, stringHandler(tt.response)).Methods(tt.method)
+		}
+
+		router.Use(CORSMethodMiddleware(router))
+
+		for _, tt := range cases {
+			rr := httptest.NewRecorder()
+			req := newRequest("OPTIONS", tt.testURL)
+
+			router.ServeHTTP(rr, req)
+
+			allowedMethods := rr.HeaderMap.Get("Access-Control-Allow-Methods")
+
+			if want, have := 200, rr.Result().StatusCode; have != want {
+				t.Errorf("Expected status code %d, found %d", want, have)
+			}
+
+			if allowedMethods != tt.expectedAllowedMethods {
+				t.Errorf("Expected Access-Control-Allow-Methods '%s', found '%s'", tt.expectedAllowedMethods, allowedMethods)
+			}
+		}
+	})
+}
+
 // Create a router, attach a route, and apply the middleware.
 func ExampleCORSMethodMiddleware() {
 	router := NewRouter()

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -348,10 +348,10 @@ func TestCORSMethodMiddleware(t *testing.T) {
 		testURL                string
 		expectedAllowedMethods string
 	}{
-		{"/g/{o}", "a", "POST", "/g/asdf", "POST,PUT,GET,OPTIONS"},
-		{"/g/{o}", "b", "PUT", "/g/bla", "POST,PUT,GET,OPTIONS"},
-		{"/g/{o}", "c", "GET", "/g/orilla", "POST,PUT,GET,OPTIONS"},
-		{"/g", "d", "POST", "/g", "POST,OPTIONS"},
+		{"/g/{o}", "a", "POST", "/g/asdf", "POST,PUT,GET"},
+		{"/g/{o}", "b", "PUT", "/g/bla", "POST,PUT,GET"},
+		{"/g/{o}", "c", "GET", "/g/orilla", "POST,PUT,GET"},
+		{"/g", "d", "POST", "/g", "POST"},
 	}
 
 	for _, tt := range cases {

--- a/route.go
+++ b/route.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 )
 
-var ErrRouteHasNoMethods = errors.New("mux: route doesn't have methods")
-
 // Route stores information to match a request and build URLs.
 type Route struct {
 	// Parent where the route was registered (a Router).
@@ -673,7 +671,7 @@ func (r *Route) GetMethods() ([]string, error) {
 			return []string(methods), nil
 		}
 	}
-	return nil, ErrRouteHasNoMethods
+	return nil, errors.New("mux: route doesn't have methods")
 }
 
 // GetHostTemplate returns the template used to build the

--- a/route.go
+++ b/route.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 )
 
+var ErrRouteHasNoMethods = errors.New("mux: route doesn't have methods")
+
 // Route stores information to match a request and build URLs.
 type Route struct {
 	// Parent where the route was registered (a Router).
@@ -671,7 +673,7 @@ func (r *Route) GetMethods() ([]string, error) {
 			return []string(methods), nil
 		}
 	}
-	return nil, errors.New("mux: route doesn't have methods")
+	return nil, ErrRouteHasNoMethods
 }
 
 // GetHostTemplate returns the template used to build the


### PR DESCRIPTION
and add a note on how Methods matchers have to be set in order for the
middleware to respod to OPTIONS calls.

Fixes #381