### PR TITLE
fix scheme matching for path only requests

### DIFF
--- a/route.go
+++ b/route.go
@@ -415,7 +415,14 @@ func (r *Route) Queries(pairs ...string) *Route {
 type schemeMatcher []string
 
 func (m schemeMatcher) Match(r *http.Request, match *RouteMatch) bool {
-	return matchInArray(m, r.URL.Scheme)
+	scheme := r.URL.Scheme
+	if scheme == "" {
+		scheme = "http"
+		if r.TLS != nil {
+			scheme = "https"
+		}
+	}
+	return matchInArray(m, scheme)
 }
 
 // Schemes adds a matcher for URL schemes.


### PR DESCRIPTION
Path only requests (with Host set in header) have empty `r.URL.Scheme`, and scheme matching will always fail. Test cases and fix added. related to #17 