### PR TITLE
Always run on the latest stable Go version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
     - go: 1.9.x
     - go: 1.10.x
     - go: 1.11.x
+    - go: 1.x
+      env: LATEST=true
     - go: tip
   allow_failures:
     - go: tip
@@ -18,5 +20,5 @@ install:
 script:
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d .)
-  - go tool vet .
+  - if [[ "$LATEST" = true ]]; then go tool vet .; fi
   - go test -v -race ./...


### PR DESCRIPTION
Only run vet on the latest Go version.