### PR TITLE
Use constant for 301 status code in regexp.go

### DIFF
--- a/regexp.go
+++ b/regexp.go
@@ -296,7 +296,7 @@ func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) 
 					} else {
 						u.Path += "/"
 					}
-					m.Handler = http.RedirectHandler(u.String(), 301)
+					m.Handler = http.RedirectHandler(u.String(), http.StatusMovedPermanently)
 				}
 			}
 		}


### PR DESCRIPTION
Go provides HTTP status codes as constants