### PR TITLE
Refactor custom handlers logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,11 +491,11 @@ r.Use(amw.Middleware)
 
 Note: The handler chain will be stopped if your middleware doesn't call `next.ServeHTTP()` with the corresponding parameters. This can be used to abort a request if the middleware writer wants to. Middlewares _should_ write to `ResponseWriter` if they _are_ going to terminate the request, and they _should not_ write to `ResponseWriter` if they _are not_ going to terminate it.
 
-#### Middlewares on route-not-found
+#### Middlewares and Routing
 
-Middlwares only run when a route is found. If the request can't be matched, including if the method is not allowed, the middlewares will be skipped.
+Middlewares only run when a route is found. If the request can't be matched, including if the method is not allowed, the middlewares will be skipped.
 
-This is also true if you specify a custom `MethodNotAllowedHandler` or `NotFoundHandler`.
+This is also true if you specify a custom `MethodNotAllowedHandler` or `NotFoundHandler`: middlewares will not be attached to these handlers.
 
 To _also_ run a middleware on a custom handler, apply it manually:
 

--- a/README.md
+++ b/README.md
@@ -491,6 +491,24 @@ r.Use(amw.Middleware)
 
 Note: The handler chain will be stopped if your middleware doesn't call `next.ServeHTTP()` with the corresponding parameters. This can be used to abort a request if the middleware writer wants to. Middlewares _should_ write to `ResponseWriter` if they _are_ going to terminate the request, and they _should not_ write to `ResponseWriter` if they _are not_ going to terminate it.
 
+#### Middlewares on route-not-found
+
+Middlwares only run when a route is found. If the request can't be matched, including if the method is not allowed, the middlewares will be skipped.
+
+This is also true if you specify a custom `MethodNotAllowedHandler` or `NotFoundHandler`.
+
+To _also_ run a middleware on a custom handler, apply it manually:
+
+```go
+r := mux.NewRouter()
+h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    io.WriteString(w, "Nothing to see here")
+    w.WriteHeader(http.StatusNotFound)
+})
+h = loggingMiddleware(h)
+r.NotFoundHandler = h
+```
+
 ### Testing Handlers
 
 Testing handlers in a Go web application is straightforward, and _mux_ doesn't complicate this any further. Given two files: `endpoints.go` and `endpoints_test.go`, here's how we'd test an application using _mux_.

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -212,7 +212,7 @@ func TestMiddlewareNotFound(t *testing.T) {
 func TestMiddlewareMethodMismatch(t *testing.T) {
 	mwStr := []byte("Middleware\n")
 	handlerStr := []byte("Logic\n")
-	mnaStr := []byte("Method not allowed")
+	mnaStr := []byte("Method not allowed\n")
 
 	router := NewRouter()
 	router.HandleFunc("/", func(w http.ResponseWriter, e *http.Request) {

--- a/mux_test.go
+++ b/mux_test.go
@@ -2023,8 +2023,7 @@ func TestNoMatchMethodErrorHandler(t *testing.T) {
 
 // Below, we compare the handlers.
 // We need an actual struct pointer since Go doesn't support function comparison
-type emptyHandler struct {
-}
+type emptyHandler struct{}
 
 func (f *emptyHandler) ServeHTTP(_ http.ResponseWriter, _ *http.Request) {
 }


### PR DESCRIPTION
Fixes #411
Closes https://github.com/gorilla/mux/pull/417

This is a more comprehensive attempt, streamlining some of the intricate logic.
It does introduce a BC-break since previously a non-match with a custom handler was considered a match, but I feel this is mostly an internal state that shouldn't affect end-users.

Plenty of tests were added.

---

custom handler:
- Do not report "matched" when finding a custom handler
- Bubble up the handler that was found and do not override the custom
  handler when applying default behavior.
- Now it "matches" if and only if MatchErr is nil

methodMatcher:
- Maintain only one methodMatcher
- Append methods to existing methodMatcher when Methods() is called again
- Set the ErrMethodMismatch in the methodMatcher