### PR TITLE
Add stalebot config

### DIFF
--- a/.github/stale
+++ b/.github/stale
@@ -1,0 +1,11 @@
+daysUntilStale: 60
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - v2
+  - needs-review
+staleLabel: stale
+markComment: >
+  This issue has been automatically marked as stale because it hasn't seen
+  a recent update. It'll be automatically closed in a few days.
+closeComment: false


### PR DESCRIPTION
Ref: https://github.com/apps/stale/

This will mark any issue without the `v2` or `needs-review` labels as stale after 60 days. It'll help with issue triage and (hopefully) motivate issue reporters to consider taking on the work directly.