### PR TITLE
fix for issue #429

### DIFF
--- a/middleware_test.go
+++ b/middleware_test.go
@@ -173,7 +173,7 @@ func TestMultipleSubrouterMiddleware(t *testing.T) {
 	req = newRequest("GET", "/subr1")
 	router.ServeHTTP(rw, req)
 	if rmw.timesCalled != 2 {
-		t.Fatalf("Expected root middleware %d calls, but got %d", 1, rmw.timesCalled)
+		t.Fatalf("Expected root middleware %d calls, but got %d", 2, rmw.timesCalled)
 	}
 	if sr1mw.timesCalled != 1 {
 		t.Fatalf("Expected root middleware %d calls, but got %d", 1, sr1mw.timesCalled)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -163,10 +163,10 @@ func TestMultipleSubrouterMiddleware(t *testing.T) {
 		t.Fatalf("Expected root middleware %d calls, but got %d", 1, rmw.timesCalled)
 	}
 	if sr1mw.timesCalled != 0 {
-		t.Fatalf("Expected root middleware %d calls, but got %d", 0, sr1mw.timesCalled)
+		t.Fatalf("Expected subrouter1 middleware %d calls, but got %d", 0, sr1mw.timesCalled)
 	}
 	if sr2mw.timesCalled != 0 {
-		t.Fatalf("Expected root middleware %d calls, but got %d", 0, sr2mw.timesCalled)
+		t.Fatalf("Expected subrouter2 middleware %d calls, but got %d", 0, sr2mw.timesCalled)
 	}
 
 	// test /subr1 calls root middleware and submux1 middleware but not submux2 middleware
@@ -176,10 +176,10 @@ func TestMultipleSubrouterMiddleware(t *testing.T) {
 		t.Fatalf("Expected root middleware %d calls, but got %d", 2, rmw.timesCalled)
 	}
 	if sr1mw.timesCalled != 1 {
-		t.Fatalf("Expected root middleware %d calls, but got %d", 1, sr1mw.timesCalled)
+		t.Fatalf("Expected subrouter1 middleware %d calls, but got %d", 1, sr1mw.timesCalled)
 	}
 	if sr2mw.timesCalled != 0 {
-		t.Fatalf("Expected root middleware %d calls, but got %d", 0, sr2mw.timesCalled)
+		t.Fatalf("Expected subrouter2 middleware %d calls, but got %d", 0, sr2mw.timesCalled)
 	}
 
 	// test /subr2 calls root middleware and submux2 middleware but not submux1 middleware
@@ -189,10 +189,10 @@ func TestMultipleSubrouterMiddleware(t *testing.T) {
 		t.Fatalf("Expected root middleware %d calls, but got %d", 3, rmw.timesCalled)
 	}
 	if sr1mw.timesCalled != 1 {
-		t.Fatalf("Expected root middleware %d calls, but got %d", 1, sr1mw.timesCalled)
+		t.Fatalf("Expected subrouter1 middleware %d calls, but got %d", 1, sr1mw.timesCalled)
 	}
 	if sr2mw.timesCalled != 1 {
-		t.Fatalf("Expected root middleware %d calls, but got %d", 1, sr2mw.timesCalled)
+		t.Fatalf("Expected subrouter2 middleware %d calls, but got %d", 1, sr2mw.timesCalled)
 	}
 }
 

--- a/route.go
+++ b/route.go
@@ -57,8 +57,8 @@ func (r *Route) Match(req *http.Request, match *RouteMatch) bool {
 		}
 	}
 
+	match.MatchErr = matchErr
 	if matchErr != nil {
-		match.MatchErr = matchErr
 		return false
 	}
 


### PR DESCRIPTION
Details are in Issue #429 - @tomare suggested a patch and it seems to work for me. 

The test I added verifies that when multiple submuxes hang off a parent mux, each gets the appropriate middleware called according to the routes assigned.