### PR TITLE
Call WriteHeader after setting other header(s) in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,8 +503,8 @@ package main
 
 func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
     // A very simple health check.
-    w.WriteHeader(http.StatusOK)
     w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
 
     // In the future we could report back on the status of our DB, or our cache
     // (e.g. Redis) by performing a simple PING, and include them in the response.


### PR DESCRIPTION
From the docs: Changing the header map after a call to WriteHeader (or
Write) has no effect unless the modified headers are
trailers.