### PR TITLE
fix go1.12 go vet usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ install:
 script:
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d .)
-  - if [[ "$LATEST" = true ]]; then go tool vet .; fi
+  - if [[ "$LATEST" = true ]]; then go vet .; fi
   - go test -v -race ./...


### PR DESCRIPTION
`go vet` instead of `go tool vet`

![screen shot 2019-02-27 at 2 28 38 pm](https://user-images.githubusercontent.com/6145422/53517180-0eda2f80-3a9c-11e9-88a5-e66776b19a14.png)
