### PR TITLE
CORSMethodMiddleware removing unexpected behaviour

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -33,9 +33,11 @@ func (r *Router) useInterface(mw middleware) {
 }
 
 // CORSMethodMiddleware sets the Access-Control-Allow-Methods response header
-// on a request, by matching routes based only on paths. It also handles
-// OPTIONS requests, by settings Access-Control-Allow-Methods, and then
-// returning without calling the next http handler.
+// on a request, by matching routes based only on paths. The headers will NOT be
+// returned if the handlers do not explicitly specify the list of supported methods.
+// This middleware also handles OPTIONS requests if allowed by the handler methods,
+// by settings Access-Control-Allow-Methods, and then returning without calling
+// the next http handler.
 func CORSMethodMiddleware(r *Router) MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -59,7 +61,7 @@ func CORSMethodMiddleware(r *Router) MiddlewareFunc {
 			})
 
 			if err == nil {
-				w.Header().Set("Access-Control-Allow-Methods", strings.Join(append(allMethods, "OPTIONS"), ","))
+				w.Header().Set("Access-Control-Allow-Methods", strings.Join(allMethods, ","))
 
 				if req.Method == "OPTIONS" {
 					return

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -343,10 +343,13 @@ func TestCORSMethodMiddleware(t *testing.T) {
 	cases := []struct {
 		requestMethod          string
 		methods                []string
+		expectedResponseCode   int
 		expectedResponse       string
 		expectedAllowedMethods string
 	}{
-		{"POST", []string{"POST", "PUT", "GET"}, responseBody, "POST,PUT,GET,OPTIONS"},
+		{"POST", []string{"POST", "PUT", "GET"}, 200, responseBody, "POST,PUT,GET"},
+		{"OPTIONS", []string{"POST", "PUT", "GET"}, 405, "", ""},
+		{"OPTIONS", []string{"POST", "PUT", "GET", "OPTIONS"}, 200, "", "POST,PUT,GET,OPTIONS"},
 	}
 
 	for _, tt := range cases {
@@ -358,6 +361,10 @@ func TestCORSMethodMiddleware(t *testing.T) {
 		req := newRequest(tt.requestMethod, handleURL)
 
 		router.ServeHTTP(rr, req)
+
+		if rr.Code != tt.expectedResponseCode {
+			t.Errorf("Expected response code '%d', found '%d'", tt.expectedResponseCode, rr.Code)
+		}
 
 		if rr.Body.String() != tt.expectedResponse {
 			t.Errorf("Expected body '%s', found '%s'", tt.expectedResponse, rr.Body.String())


### PR DESCRIPTION
I got a feeling that CORSMethodMiddleware got stuck between several iterations, and current condition does not make much sense to me.

See for yourself:
- If you don't specify `.Methods()` it does not work at all. That was not documented in the actual body of the middleware until this PR and it's actually needs effort to discover.
- If you do specify `.Methods("GET, "POST")` it starts to work and return the headers, but for some reason returns that you also support `OPTIONS`, which you don't, because all OPTIONS calls end up with 405 response and no headers are being set.
- If you do specify that your endpoint support OPTIONS with `.Methods("GET", "POST", "OPTIONS")` the middleware outputs something weird back to the users: `"Access-Control-Allow-Methods": "GET,POST,OPTIONS,OPTIONS"`.

I've seen that @pierreprinetti was bringing this problem before (https://github.com/gorilla/mux/issues/381, https://github.com/gorilla/mux/pull/382), and the fix was not merged for different reasons and different ideas on how things could work in Mux in the future, but since that time things have changed, and only the Middleware still keeps behaving unexpectedly and weirdly both for end users and for developers.

So without the second-commit fix the tests would fail like this:
```
Expected Access-Control-Allow-Methods 'POST,PUT,GET,OPTIONS', 
found 'POST,PUT,GET,OPTIONS,OPTIONS'
FAIL
```

I've also improved the test to remove unnecessary complexity of different similar conditions testing and actually testing out more things.

Looking forward to hear what do you think about this change!