### PR TITLE
Guess the scheme if r.URL.Scheme is unset

### DIFF
--- a/mux_httpserver_test.go
+++ b/mux_httpserver_test.go
@@ -1,0 +1,46 @@
+// +build go1.9
+
+package mux
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSchemeMatchers(t *testing.T) {
+	router := NewRouter()
+	router.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+		rw.Write([]byte("hello world"))
+	}).Schemes("http", "https")
+
+	assertHelloWorldResponse := func(t *testing.T, s *httptest.Server) {
+		resp, err := s.Client().Get(s.URL)
+		if err != nil {
+			t.Fatalf("unexpected error getting from server: %v", err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("expected a status code of 200, got %v", resp.StatusCode)
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("unexpected error reading body: %v", err)
+		}
+		if !bytes.Equal(body, []byte("hello world")) {
+			t.Fatalf("response should be hello world, was: %q", string(body))
+		}
+	}
+
+	t.Run("httpServer", func(t *testing.T) {
+		s := httptest.NewServer(router)
+		defer s.Close()
+		assertHelloWorldResponse(t, s)
+	})
+	t.Run("httpsServer", func(t *testing.T) {
+		s := httptest.NewTLSServer(router)
+		defer s.Close()
+		assertHelloWorldResponse(t, s)
+	})
+}

--- a/mux_httpserver_test.go
+++ b/mux_httpserver_test.go
@@ -11,10 +11,14 @@ import (
 )
 
 func TestSchemeMatchers(t *testing.T) {
-	router := NewRouter()
-	router.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+	httpRouter := NewRouter()
+	httpRouter.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
 		rw.Write([]byte("hello world"))
-	}).Schemes("http", "https")
+	}).Schemes("http")
+	httpsRouter := NewRouter()
+	httpsRouter.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+		rw.Write([]byte("hello world"))
+	}).Schemes("https")
 
 	assertHelloWorldResponse := func(t *testing.T, s *httptest.Server) {
 		resp, err := s.Client().Get(s.URL)
@@ -34,12 +38,12 @@ func TestSchemeMatchers(t *testing.T) {
 	}
 
 	t.Run("httpServer", func(t *testing.T) {
-		s := httptest.NewServer(router)
+		s := httptest.NewServer(httpRouter)
 		defer s.Close()
 		assertHelloWorldResponse(t, s)
 	})
 	t.Run("httpsServer", func(t *testing.T) {
-		s := httptest.NewTLSServer(router)
+		s := httptest.NewTLSServer(httpsRouter)
 		defer s.Close()
 		assertHelloWorldResponse(t, s)
 	})

--- a/mux_httpserver_test.go
+++ b/mux_httpserver_test.go
@@ -11,16 +11,15 @@ import (
 )
 
 func TestSchemeMatchers(t *testing.T) {
-	httpRouter := NewRouter()
-	httpRouter.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
-		rw.Write([]byte("hello world"))
+	router := NewRouter()
+	router.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+		rw.Write([]byte("hello http world"))
 	}).Schemes("http")
-	httpsRouter := NewRouter()
-	httpsRouter.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
-		rw.Write([]byte("hello world"))
+	router.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+		rw.Write([]byte("hello https world"))
 	}).Schemes("https")
 
-	assertHelloWorldResponse := func(t *testing.T, s *httptest.Server) {
+	assertResponseBody := func(t *testing.T, s *httptest.Server, expectedBody string) {
 		resp, err := s.Client().Get(s.URL)
 		if err != nil {
 			t.Fatalf("unexpected error getting from server: %v", err)
@@ -32,19 +31,19 @@ func TestSchemeMatchers(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error reading body: %v", err)
 		}
-		if !bytes.Equal(body, []byte("hello world")) {
+		if !bytes.Equal(body, []byte(expectedBody)) {
 			t.Fatalf("response should be hello world, was: %q", string(body))
 		}
 	}
 
 	t.Run("httpServer", func(t *testing.T) {
-		s := httptest.NewServer(httpRouter)
+		s := httptest.NewServer(router)
 		defer s.Close()
-		assertHelloWorldResponse(t, s)
+		assertResponseBody(t, s, "hello http world")
 	})
 	t.Run("httpsServer", func(t *testing.T) {
-		s := httptest.NewTLSServer(httpsRouter)
+		s := httptest.NewTLSServer(router)
 		defer s.Close()
-		assertHelloWorldResponse(t, s)
+		assertResponseBody(t, s, "hello https world")
 	})
 }

--- a/mux_test.go
+++ b/mux_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"reflect"
 	"strings"
@@ -2837,10 +2838,7 @@ func newRequestWithHeaders(method, url string, headers ...string) *http.Request 
 
 // newRequestHost a new request with a method, url, and host header
 func newRequestHost(method, url, host string) *http.Request {
-	req, err := http.NewRequest(method, url, nil)
-	if err != nil {
-		panic(err)
-	}
+	req := httptest.NewRequest(method, url, nil)
 	req.Host = host
 	return req
 }

--- a/old_test.go
+++ b/old_test.go
@@ -385,6 +385,11 @@ var urlBuildingTests = []urlBuildingTest{
 		vars:  []string{"subdomain", "foo", "category", "technology", "id", "42"},
 		url:   "http://foo.domain.com/articles/technology/42",
 	},
+	{
+		route: new(Route).Host("example.com").Schemes("https", "http"),
+		vars:  []string{},
+		url:   "https://example.com",
+	},
 }
 
 func TestHeaderMatcher(t *testing.T) {
@@ -502,18 +507,6 @@ func TestUrlBuilding(t *testing.T) {
 		url := u.String()
 		if url != v.url {
 			t.Errorf("expected %v, got %v", v.url, url)
-			/*
-				reversePath := ""
-				reverseHost := ""
-				if v.route.pathTemplate != nil {
-						reversePath = v.route.pathTemplate.Reverse
-				}
-				if v.route.hostTemplate != nil {
-						reverseHost = v.route.hostTemplate.Reverse
-				}
-
-				t.Errorf("%#v:\nexpected: %q\ngot: %q\nreverse path: %q\nreverse host: %q", v.route, v.url, url, reversePath, reverseHost)
-			*/
 		}
 	}
 

--- a/route.go
+++ b/route.go
@@ -412,7 +412,20 @@ func (r *Route) Queries(pairs ...string) *Route {
 type schemeMatcher []string
 
 func (m schemeMatcher) Match(r *http.Request, match *RouteMatch) bool {
-	return matchInArray(m, r.URL.Scheme)
+	scheme := r.URL.Scheme
+	// https://golang.org/pkg/net/http/#Request
+	// "For [most] server requests, fields other than Path and RawQuery will be
+	// empty."
+	// Since we're an http muxer, the scheme is either going to be http or https
+	// though, so we can just set it based on the tls termination state.
+	if scheme == "" {
+		if r.TLS == nil {
+			scheme = "http"
+		} else {
+			scheme = "https"
+		}
+	}
+	return matchInArray(m, scheme)
 }
 
 // Schemes adds a matcher for URL schemes.

--- a/route.go
+++ b/route.go
@@ -430,6 +430,12 @@ func (m schemeMatcher) Match(r *http.Request, match *RouteMatch) bool {
 
 // Schemes adds a matcher for URL schemes.
 // It accepts a sequence of schemes to be matched, e.g.: "http", "https".
+// If the request's URL has a scheme set, it will be matched against.
+// Generally, the URL scheme will only be set if a previous handler set it,
+// such as the ProxyHeaders handler from gorilla/handlers.
+// If unset, the scheme will be determined based on the request's TLS
+// termination state.
+// The first argument to Schemes will be used when constructing a route URL.
 func (r *Route) Schemes(schemes ...string) *Route {
 	for k, v := range schemes {
 		schemes[k] = strings.ToLower(v)
@@ -506,14 +512,21 @@ func (r *Route) Subrouter() *Router {
 // This also works for host variables:
 //
 //     r := mux.NewRouter()
-//     r.Host("{subdomain}.domain.com").
-//       HandleFunc("/articles/{category}/{id:[0-9]+}", ArticleHandler).
+//     r.HandleFunc("/articles/{category}/{id:[0-9]+}", ArticleHandler).
+//       Host("{subdomain}.domain.com").
 //       Name("article")
 //
 //     // url.String() will be "http://news.domain.com/articles/technology/42"
 //     url, err := r.Get("article").URL("subdomain", "news",
 //                                      "category", "technology",
 //                                      "id", "42")
+//
+// The scheme of the resulting url will be the first argument that was passed to Schemes:
+//
+//     // url.String() will be "https://example.com"
+//     r := mux.NewRouter()
+//     url, err := r.Host("example.com")
+//                  .Schemes("https", "http").URL()
 //
 // All variables defined in the route are required, and their values must
 // conform to the corresponding patterns.


### PR DESCRIPTION
It's not expected that the request's URL is fully populated when used on
the server-side (it's more of a client-side field), so we shouldn't
expect it to be present.

In practice, it's only rarely set at all on the server, making mux's
`Schemes` matcher tricky to use as it is.

This commit adds a test which would have failed before demonstrating the
problem, as well as a fix which I think makes `.Schemes` match what
users expect.

This will technically break anyone who did the following:

```go
router.Schemes("") // match http and https
```