### PR TITLE
Configure Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,19 @@
+env:
+  CIRRUS_WORKING_DIR: /go/src/github.com/gorilla/mux
+
+test_task:
+  matrix:
+    - container:
+        image: golang:latest
+      vet_script: go vet . # extra script
+    - container:
+        matrix: 
+          - image: golang:1.7
+          - image: golang:1.8
+          - image: golang:1.9
+          - image: golang:1.10
+          - image: golang:1.11
+          - image: golang:1.12
+  get_script: go get -t -v ./...
+  fmt_script: diff -u <(echo -n) <(gofmt -d .)
+  test_script: go test -v -race ./...


### PR DESCRIPTION
@elithrar, saw that you were checking out different CIs for the project. Want to bring Cirrus CI for your consideration. Cirrus can use the official Go Docker containers for testing and they run pretty quickly:

![image](https://user-images.githubusercontent.com/989066/59569775-46291800-905c-11e9-9cdf-6d83155d2a67.png)

Here is a link to [the build](https://cirrus-ci.com/build/6300121411616768).

**Disclaimer:** I work on Cirrus CI. 😅 

Feel free to close the PR if not interested. 🙌 