### PR TITLE
Add documentation for using mux to serve a SPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ func main() {
 
 Most of the time it makes sense to serve your SPA on a separate web server from your API,
 but sometimes it's desirable to serve them both from one place. It's possible to write a simple
-handler for serving your SPA (for use with React's BrowserRouter for example), and leverage
+handler for serving your SPA (for use with React Router's [BrowserRouter](https://reacttraining.com/react-router/web/api/BrowserRouter) for example), and leverage
 mux's powerful routing for your API endpoints.
 
 ```go

--- a/README.md
+++ b/README.md
@@ -234,30 +234,46 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// spaHandler implements the http.Handler interface, so we can use it
+// to respond to HTTP requests. The path to the static directory and
+// path to the index file within that static directory are used to
+// serve the SPA in the given static directory.
 type spaHandler struct {
 	staticPath string
 	indexPath  string
 }
 
+// ServeHTTP inspects the URL path to locate a file within the static dir
+// on the SPA handler. If a file is found, it will be served. If not, the
+// file located at the index path on the SPA handler will be served. This
+// is suitable behavior for serving an SPA (single page application).
 func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    // get the absolute path to prevent directory traversal
 	path, err := filepath.Abs(r.URL.Path)
 	if err != nil {
+        // if we failed to get the absolute path respond with a 400 bad request
+        // and stop
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
+    // prepend the path with the path to the static directory
 	path = filepath.Join(h.staticPath, path)
 
+    // check whether a file exists at the given path
 	_, err = os.Stat(path)
 	if os.IsNotExist(err) {
 		// file does not exist, serve index.html
 		http.ServeFile(w, r, filepath.Join(h.staticPath, h.indexPath))
 		return
 	} else if err != nil {
+        // if we got an error (that wasn't that the file doesn't exist) stating the
+        // file, return a 500 internal server error and stop
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
+    // otherwise, use http.FileServer to serve the static dir
 	http.FileServer(http.Dir(h.staticPath)).ServeHTTP(w, r)
 }
 

--- a/README.md
+++ b/README.md
@@ -262,18 +262,18 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	r := mux.NewRouter()
+	router := mux.NewRouter()
 
-	r.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
 		// an example API handler
 		json.NewEncoder(w).Encode(map[string]bool{"ok": true})
 	})
 
 	spa := spaHandler{staticPath: "build", indexPath: "index.html"}
-	r.PathPrefix("/").Handler(spa)
+	router.PathPrefix("/").Handler(spa)
 
 	srv := &http.Server{
-		Handler: r,
+		Handler: router,
 		Addr:    "127.0.0.1:8000",
 		// Good practice: enforce timeouts for servers you create!
 		WriteTimeout: 15 * time.Second,

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The name mux stands for "HTTP request multiplexer". Like the standard `http.Serv
 * [Examples](#examples)
 * [Matching Routes](#matching-routes)
 * [Static Files](#static-files)
-* [Serving SPAs](#serving-spas)
+* [Serving Single Page Applications](#serving-single-page-applications) (e.g. React, Vue, Ember.js, etc.)
 * [Registered URLs](#registered-urls)
 * [Walking Routes](#walking-routes)
 * [Graceful Shutdown](#graceful-shutdown)
@@ -213,7 +213,7 @@ func main() {
 }
 ```
 
-### Serving SPAs
+### Serving Single Page Applications
 
 Most of the time it makes sense to serve your SPA on a separate web server from your API,
 but sometimes it's desirable to serve them both from one place. It's possible to write a simple

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/gorilla/mux
+
+go 1.12


### PR DESCRIPTION
Fixes #464

**Summary of Changes**

1. Adds documentation to the README.md for using mux to serve API endpoints alongside a SPA.

**Testing**

I ran create-react-app, made a prod build, copied the build directory, and tested this out. Seems to work great.