### PR TITLE
Fixed golint warnings

### DIFF
--- a/regexp.go
+++ b/regexp.go
@@ -181,16 +181,16 @@ func (r *routeRegexp) Match(req *http.Request, match *RouteMatch) bool {
 			}
 		}
 		return r.regexp.MatchString(host)
-	} else {
-		if r.regexpType == regexpTypeQuery {
-			return r.matchQueryString(req)
-		}
-		path := req.URL.Path
-		if r.options.useEncodedPath {
-			path = req.URL.EscapedPath()
-		}
-		return r.regexp.MatchString(path)
 	}
+
+	if r.regexpType == regexpTypeQuery {
+		return r.matchQueryString(req)
+	}
+	path := req.URL.Path
+	if r.options.useEncodedPath {
+		path = req.URL.EscapedPath()
+	}
+	return r.regexp.MatchString(path)
 }
 
 // url builds a URL part using the given values.


### PR DESCRIPTION
Fixed:
1. mux.go:366:5: error var SkipRouter should have name of the form ErrFoo
2. regexp.go:184:9: if block ends with a return statement, so drop this else and outdent its block
