### PR TITLE
Fix the CORSMethodMiddleware bug with subrouters

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -58,22 +58,17 @@ func CORSMethodMiddleware(r *Router) MiddlewareFunc {
 func getAllMethodsForRoute(r *Router, req *http.Request) ([]string, error) {
 	var allMethods []string
 
-	err := r.Walk(func(route *Route, _ *Router, _ []*Route) error {
-		for _, m := range route.matchers {
-			if _, ok := m.(*routeRegexp); ok {
-				if m.Match(req, &RouteMatch{}) {
-					methods, err := route.GetMethods()
-					if err != nil {
-						return err
-					}
-
-					allMethods = append(allMethods, methods...)
-				}
-				break
+	for _, route := range r.routes {
+		var match RouteMatch
+		if route.Match(req, &match) || match.MatchErr == ErrMethodMismatch {
+			methods, err := route.GetMethods()
+			if err != nil {
+				return nil, err
 			}
-		}
-		return nil
-	})
 
-	return allMethods, err
+			allMethods = append(allMethods, methods...)
+		}
+	}
+
+	return allMethods, nil
 }


### PR DESCRIPTION
Fixes #534 

**Summary of Changes**

1. Adds a test case for the repro given in issue #534
2. Fixes the logic in CORSMethodMiddleware to handle matching routes better (now more closely mirrors the way routes are actually matched, just ignoring method mismatch errors)
