### PR TITLE
Remove stale text from comment.

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -435,8 +435,7 @@ func Vars(r *http.Request) map[string]string {
 // CurrentRoute returns the matched route for the current request, if any.
 // This only works when called inside the handler of the matched route
 // because the matched route is stored in the request context which is cleared
-// after the handler returns, unless the KeepContext option is set on the
-// Router.
+// after the handler returns.
 func CurrentRoute(r *http.Request) *Route {
 	if rv := r.Context().Value(routeKey); rv != nil {
 		return rv.(*Route)


### PR DESCRIPTION


Fixes #

Comment for CurrentRoute claimed that setting the KeepContext option would propagate
the Route even after the request. The KeepContext option is deprecated and has no effect.

> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!
