### PR TITLE
Added a fuzzer

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,9 @@
+package mux
+
+func Fuzz(data []byte) int {
+	_, err := newRouteRegexp(string(data), regexpTypeHost, routeRegexpOptions{})
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds a fuzzer for the Regexp functionality. It does not modify any core functionality.

The fuzzer can be run locally, and I will be happy to setup continuous fuzzing as well through oss-fuzz. This would allow Google to run the fuzzer periodically and notify maintainers in case any bugs were found.

A small note on this fuzzer: It panics [here](https://github.com/gorilla/mux/blob/master/regexp.go#L135), and the optimal solution to that would be to remove the panic from a point of view of fuzzing. However, since there is just a single panic in regexp.go, we could remove it during fuzzing runs or rewrite it slightly to not stop the fuzzer. This would be the solution in the case on running continuous fuzzing.

Signed-off-by: AdamKorcz <adam@adalogics.com>