### PR TITLE
Stripe tail slash in PathPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ r.Host("{subdomain:[a-z]+}.example.com")
 There are several other matchers that can be added. To match path prefixes:
 
 ```go
-r.PathPrefix("/products/")
+r.PathPrefix("/products")
 ```
 
 ...or HTTP methods:


### PR DESCRIPTION
As I was following the example and Test the API for the first time (BY THE WAY IT IS AWWWWSOME! & I LOVE IT)
I just had a problem in example and I figured out that maybe this would be misleading for other noob devs like me

Thanks so much

