### PR TITLE
🔥Removed Mux webpage URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 ![Gorilla Logo](https://cloud-cdn.questionable.services/gorilla-icon-64.png)
 
-https://www.gorillatoolkit.org/pkg/mux
-
 Package `gorilla/mux` implements a request router and dispatcher for matching incoming requests to
 their respective handler.
 


### PR DESCRIPTION
I have removed the Mux webpage URL from the README because the URL results to an "Internal Error".

## Fixes

**Summary of Changes**

1. Removed Mux webpage URL