### PR TITLE
Include "404" and "405" in the docs

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -46,9 +46,11 @@ func NewRouter() *Router {
 // This will send all incoming requests to the router.
 type Router struct {
 	// Configurable Handler to be used when no route matches.
+	// This can be used to render your own 404 Not Found errors.
 	NotFoundHandler http.Handler
 
 	// Configurable Handler to be used when the request method does not match the route.
+	// This can be used to render your own 405 Method Not Allowed errors.
 	MethodNotAllowedHandler http.Handler
 
 	// Routes to be matched, in order.


### PR DESCRIPTION
I was searching for 404 in the docs and didn't find anything and almost assumed Mux didn't have the ability for a custom 404 handlers. Add another sentence with "404" and "Not Found" so quick searching can find them.

Same for 405.