### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ func main() {
     // <-ctx.Done() if your application should wait for other services
     // to finalize based on context cancellation.
     log.Println("shutting down")
-    os.Exit(0)
+    defer os.Exit(0)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -455,7 +455,6 @@ import (
 )
 
 func main() {
-    defer os.Exit(0)
     var wait time.Duration
     flag.DurationVar(&wait, "graceful-timeout", time.Second * 15, "the duration for which the server gracefully wait for existing connections to finish - e.g. 15s or 1m")
     flag.Parse()

--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ import (
 )
 
 func main() {
+    defer os.Exit(0)
     var wait time.Duration
     flag.DurationVar(&wait, "graceful-timeout", time.Second * 15, "the duration for which the server gracefully wait for existing connections to finish - e.g. 15s or 1m")
     flag.Parse()
@@ -496,7 +497,6 @@ func main() {
     // <-ctx.Done() if your application should wait for other services
     // to finalize based on context cancellation.
     log.Println("shutting down")
-    defer os.Exit(0)
 }
 ```
 


### PR DESCRIPTION
defer os_exit

**Summary of Changes**

1. Documentation update in `README.md`

I guess it makes more sense to phrase this as a question. If we do `os.exit(0)` when above there are deferred clean ups and e.g. `defer cancel()`. I believe that `os.exit(0)` skips all deferred calls. 