### PR TITLE
Add Mount method to Route.

### DIFF
--- a/route.go
+++ b/route.go
@@ -488,6 +488,12 @@ func (r *Route) Subrouter() *Router {
 	return router
 }
 
+// Mount registers a subrouter for the route.
+func (r *Router) Mount(prefix string, wrapFunc func(r *Router)) {
+	sub := r.PathPrefix(prefix).Subrouter()
+	wrapFunc(sub)
+}
+
 // ----------------------------------------------------------------------------
 // URL building
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
With Mount method, we can simplify subrouter with tidy code.

before:
```
todos := r.PathPrefix("/todos").Subrouter()
todosResource{}.SubrouterFunc(todos)
```

now:
```
r.Mount("/todos", todosResource{}.SubrouterFunc)
```


```
type todosResource struct{}

func (rs todosResource) SubrouterFunc(r *mux.Router) {
	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		_, _ = fmt.Fprintln(w, "entry [/todos/].")
	})
	r.HandleFunc("/list", func(w http.ResponseWriter, r *http.Request) {
		_, _ = fmt.Fprintln(w, "entry [/todos/list].")
	})
}
```

Fixes #

**Summary of Changes**

1.
2. 
3.

> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!
