### PR TITLE
bugfix: set automatic redirection on routes without "/" on end of path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/gorilla/mux
+module github.com/plankiton/mux
 
 go 1.12

--- a/mux.go
+++ b/mux.go
@@ -297,7 +297,12 @@ func (r *Router) Handle(path string, handler http.Handler) *Route {
 // See Route.Path() and Route.HandlerFunc().
 func (r *Router) HandleFunc(path string, f func(http.ResponseWriter,
 	*http.Request)) *Route {
-	return r.NewRoute().Path(path).HandlerFunc(f)
+		if path[len(path)-1] != '/' {
+			r.NewRoute().Path(path+"/").HandlerFunc(f)
+		} else {
+			r.NewRoute().Path(path[:len(path)-1]).HandlerFunc(f)
+		}
+		return r.NewRoute().Path(path).HandlerFunc(f)
 }
 
 // Headers registers a new route with a matcher for request header values.


### PR DESCRIPTION
1. Always I to create a route on old version with "/user" as example, when I request "/user/" it returns a 404 error, to fix this I made the mux to create de route with "/" on end, and vice versa