### PR TITLE
Create helper method for creating middlewares from a closure

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -37,6 +37,7 @@ func NewMiddleware(mw func(http.ResponseWriter, *http.Request)) MiddlewareFunc {
 type genericMW struct {
 	process func(http.ResponseWriter, *http.Request)
 }
+
 func (instance *genericMW) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	instance.process(w, req)
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -570,7 +570,7 @@ func TestNewMiddleware(t *testing.T) {
 	mwFuncCalls := 0
 
 	handler := &mockHandler{
-		serverHttp: func(w http.ResponseWriter, r *http.Request) {
+		serverHTTP: func(w http.ResponseWriter, r *http.Request) {
 			if mwFuncCalls != 1 {
 				t.Fatalf("Expected Handler to be called after mw run. However, the middleware run {%d} times before the handler.", mwFuncCalls)
 			}
@@ -591,9 +591,9 @@ func TestNewMiddleware(t *testing.T) {
 }
 
 type mockHandler struct {
-	serverHttp func(writer http.ResponseWriter, request *http.Request)
+	serverHTTP func(writer http.ResponseWriter, request *http.Request)
 }
 
 func (d *mockHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
-	d.serverHttp(writer, request)
+	d.serverHTTP(writer, request)
 }

--- a/mux.go
+++ b/mux.go
@@ -363,9 +363,9 @@ func (r *Router) Walk(walkFn WalkFunc) error {
 	return r.walk(walkFn, []*Route{})
 }
 
-// SkipRouter is used as a return value from WalkFuncs to indicate that the
+// ErrSkipRouter is used as a return value from WalkFuncs to indicate that the
 // router that walk is about to descend down to should be skipped.
-var SkipRouter = errors.New("skip this router")
+var ErrSkipRouter = errors.New("skip this router")
 
 // WalkFunc is the type of the function called for each route visited by Walk.
 // At every invocation, it is given the current route, and the current router,
@@ -375,7 +375,7 @@ type WalkFunc func(route *Route, router *Router, ancestors []*Route) error
 func (r *Router) walk(walkFn WalkFunc, ancestors []*Route) error {
 	for _, t := range r.routes {
 		err := walkFn(t, r, ancestors)
-		if err == SkipRouter {
+		if err == ErrSkipRouter {
 			continue
 		}
 		if err != nil {

--- a/mux_httpserver_test.go
+++ b/mux_httpserver_test.go
@@ -1,5 +1,3 @@
-// +build go1.9
-
 package mux
 
 import (

--- a/mux_test.go
+++ b/mux_test.go
@@ -1600,7 +1600,7 @@ func TestWalkSingleDepth(t *testing.T) {
 	err := r0.Walk(func(route *Route, router *Router, ancestors []*Route) error {
 		matcher := route.matchers[0].(*routeRegexp)
 		if matcher.template == "/d" {
-			return SkipRouter
+			return ErrSkipRouter
 		}
 		if len(ancestors) != depths[i] {
 			t.Errorf(`Expected depth of %d at i = %d; got "%d"`, depths[i], i, len(ancestors))

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -54,7 +54,7 @@ func Benchmark_findQueryKey(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				for key, _ := range all {
+				for key := range all {
 					_, _ = findFirstQueryKey(query, key)
 				}
 			}
@@ -79,7 +79,7 @@ func Benchmark_findQueryKeyGoLib(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				for key, _ := range all {
+				for key := range all {
 					v := u.Query()[key]
 					if len(v) > 0 {
 						_ = v[0]


### PR DESCRIPTION
**Context**:
It's not possible to create a middleware just by declaring a closure or anonymous function. So I've create a helper method for creating a Middleware just by declaring the anonymous function.

Fixes #
- This PR doesn't fix any bug nor issue, it's just new functionality which makes it more comfortable to create a middleware.

**Summary of Changes**

1.Create new helper method for creating Middleware from a closure or anonymous function.
2. Unit test was added to test the new functionality.

Example:


```
NewMiddleware(func(http.ResponseWriter, *http.Request) {
 // TODO: here write the code of your middleware
})
```

Another option is to declare the function in a separate variable

```
myMiddleware := func(http.ResponseWriter, *http.Request) {
// TODO: do some stuff
}
NewMiddleware(myMiddleware)
```



> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!
