### PR TITLE
Set the Allow header when ErrMethodMismatch is set

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -2052,6 +2052,9 @@ func TestNoMatchMethodErrorHandler(t *testing.T) {
 	if resp.Code != http.StatusMethodNotAllowed {
 		t.Errorf("Expecting code %v", 405)
 	}
+	if hdr := resp.Header().Get("Allow"); hdr != "GET,POST" {
+		t.Errorf(`Expected Allow header to be "GET,POST" (got %q)`, hdr)
+	}
 
 	// Add matching route
 	r.HandleFunc("/", func1).Methods("PUT")
@@ -2721,7 +2724,6 @@ func TestMethodNotAllowed(t *testing.T) {
 	handler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
 	router := NewRouter()
 	router.HandleFunc("/thing", handler).Methods(http.MethodGet)
-	router.HandleFunc("/something", handler).Methods(http.MethodGet)
 
 	w := NewRecorder()
 	req := newRequest(http.MethodPut, "/thing")
@@ -2730,6 +2732,9 @@ func TestMethodNotAllowed(t *testing.T) {
 
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("Expected status code 405 (got %d)", w.Code)
+	}
+	if hdr := w.Header().Get("Allow"); hdr != http.MethodGet {
+		t.Fatalf(`Expected Allow header to be "GET" (got %q)`, hdr)
 	}
 }
 

--- a/route.go
+++ b/route.go
@@ -44,12 +44,14 @@ func (r *Route) Match(req *http.Request, match *RouteMatch) bool {
 	}
 
 	var matchErr error
+	var allowedMethods []string
 
 	// Match everything.
 	for _, m := range r.matchers {
 		if matched := m.Match(req, match); !matched {
-			if _, ok := m.(methodMatcher); ok {
+			if m, ok := m.(methodMatcher); ok {
 				matchErr = ErrMethodMismatch
+				allowedMethods = m
 				continue
 			}
 
@@ -71,6 +73,9 @@ func (r *Route) Match(req *http.Request, match *RouteMatch) bool {
 
 	if matchErr != nil {
 		match.MatchErr = matchErr
+		if matchErr == ErrMethodMismatch {
+			match.AllowedMethods = allowedMethods
+		}
 		return false
 	}
 


### PR DESCRIPTION
👋

As described in #554, the current default behavior of mux isn’t compliant with [RFC 7231§6.5.5][RFC7231] when 405 Method Not Allowed is returned.

This PR makes it so that `ErrMethodMismatch` becomes a struct containing the slice of methods that would be allowed by the matcher, which then makes it possible for `Router.ServeHTTP` to construct a handler that will set the `Allow` header, which solves the issue.

I also considered adding a field in `Route` that would have that slice as well (as discussed in #555), but it felt neater to set an error with the information needed. It also allows user-defined matchers to return that error, which mux would then handle correctly. Happy to reconsider, of course!

Fixes https://github.com/gorilla/mux/issues/554.

[RFC7231]: https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.5