### PR TITLE
Add a flag to unescape variable values

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -84,6 +84,8 @@ type routeConf struct {
 	// will not redirect
 	skipClean bool
 
+	unescapeVars bool
+
 	// Manager for the variables from host and path.
 	regexp routeRegexpGroup
 
@@ -257,6 +259,14 @@ func (r *Router) StrictSlash(value bool) *Router {
 // become /fetch/http/xkcd.com/534
 func (r *Router) SkipClean(value bool) *Router {
 	r.skipClean = value
+	return r
+}
+
+// UnescapeVars tells the router to escape the route variables before invoking
+// the handler. This is useful when used together with UseEncodedPath to avoid
+// un-escaping the variable values in the handler.
+func (r *Router) UnescapeVars(value bool) *Router {
+	r.unescapeVars = value
 	return r
 }
 

--- a/mux.go
+++ b/mux.go
@@ -269,10 +269,10 @@ func (r *Router) SkipClean(value bool) *Router {
 // For example, if the router is configured only with UseEncodedPath(), and
 // "/path/foo%2Fbar/to" matches the path template "/path/{var}/to", your handler
 // will receive the value "foo%2Fbar" for the variable "var". Instead, if the
-// router is configured with both UseEncodedPath() and UnescapeVars(true), the
-// value for the variable "var" will be "foo/bar".
-func (r *Router) UnescapeVars(value bool) *Router {
-	r.unescapeVars = value
+// router is configured with both UseEncodedPath() and UnescapeVars(), the value
+// for the variable "var" will be "foo/bar".
+func (r *Router) UnescapeVars() *Router {
+	r.unescapeVars = true
 	return r
 }
 

--- a/mux.go
+++ b/mux.go
@@ -265,6 +265,12 @@ func (r *Router) SkipClean(value bool) *Router {
 // UnescapeVars tells the router to escape the route variables before invoking
 // the handler. This is useful when used together with UseEncodedPath to avoid
 // un-escaping the variable values in the handler.
+//
+// For example, if the router is configured only with UseEncodedPath(), and
+// "/path/foo%2Fbar/to" matches the path template "/path/{var}/to", your handler
+// will receive the value "foo%2Fbar" for the variable "var". Instead, if the
+// router is configured with both UseEncodedPath() and UnescapeVars(true), the
+// value for the variable "var" will be "foo/bar".
 func (r *Router) UnescapeVars(value bool) *Router {
 	r.unescapeVars = value
 	return r

--- a/mux_test.go
+++ b/mux_test.go
@@ -1553,7 +1553,7 @@ func TestUseEncodedPath(t *testing.T) {
 		},
 		{
 			title:        "Router with useEncodedPath, URL with encoded slash does match, variables decoded",
-			route:        NewRouter().UseEncodedPath().UnescapeVars(true).NewRoute().Path("/v1/{v1}/v2"),
+			route:        NewRouter().UseEncodedPath().UnescapeVars().NewRoute().Path("/v1/{v1}/v2"),
 			request:      newRequest("GET", "http://localhost/v1/1%2F2/v2"),
 			vars:         map[string]string{"v1": "1/2"},
 			host:         "",

--- a/mux_test.go
+++ b/mux_test.go
@@ -1540,13 +1540,10 @@ func TestStrictSlash(t *testing.T) {
 }
 
 func TestUseEncodedPath(t *testing.T) {
-	r := NewRouter()
-	r.UseEncodedPath()
-
 	tests := []routeTest{
 		{
 			title:        "Router with useEncodedPath, URL with encoded slash does match",
-			route:        r.NewRoute().Path("/v1/{v1}/v2"),
+			route:        NewRouter().UseEncodedPath().NewRoute().Path("/v1/{v1}/v2"),
 			request:      newRequest("GET", "http://localhost/v1/1%2F2/v2"),
 			vars:         map[string]string{"v1": "1%2F2"},
 			host:         "",
@@ -1555,8 +1552,18 @@ func TestUseEncodedPath(t *testing.T) {
 			shouldMatch:  true,
 		},
 		{
+			title:        "Router with useEncodedPath, URL with encoded slash does match, variables decoded",
+			route:        NewRouter().UseEncodedPath().UnescapeVars(true).NewRoute().Path("/v1/{v1}/v2"),
+			request:      newRequest("GET", "http://localhost/v1/1%2F2/v2"),
+			vars:         map[string]string{"v1": "1/2"},
+			host:         "",
+			path:         "/v1/1%2F2/v2",
+			pathTemplate: `/v1/{v1}/v2`,
+			shouldMatch:  true,
+		},
+		{
 			title:        "Router with useEncodedPath, URL with encoded slash doesn't match",
-			route:        r.NewRoute().Path("/v1/1/2/v2"),
+			route:        NewRouter().UseEncodedPath().NewRoute().Path("/v1/1/2/v2"),
 			request:      newRequest("GET", "http://localhost/v1/1%2F2/v2"),
 			vars:         map[string]string{"v1": "1%2F2"},
 			host:         "",

--- a/route.go
+++ b/route.go
@@ -186,6 +186,7 @@ func (r *Route) addRegexpMatcher(tpl string, typ regexpType) error {
 	rr, err := newRouteRegexp(tpl, typ, routeRegexpOptions{
 		strictSlash:    r.strictSlash,
 		useEncodedPath: r.useEncodedPath,
+		unescapeVars:   r.unescapeVars,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #639

**Summary of Changes**

1. Add a new router option configurabile via `UnescapeVars`.
2. When `UnescapeVars` is active, variable values are automatically unescaped when a match is found.
3. When `UnescapeVars` is active, variable values are automatically escaped before generating the route's URL.

