### PR TITLE
add some additional benchmarks

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -5,6 +5,7 @@
 package mux
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,6 +17,96 @@ func BenchmarkMux(b *testing.B) {
 	router.HandleFunc("/v1/{v1}", handler)
 
 	request, _ := http.NewRequest("GET", "/v1/anything", nil)
+	for i := 0; i < b.N; i++ {
+		router.ServeHTTP(nil, request)
+	}
+}
+
+// Benchmark Go's built in serve mux
+func BenchmarkMuxGoStd(b *testing.B) {
+	router := http.NewServeMux()
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	router.HandleFunc("/foo", handler)
+	router.HandleFunc("/bar", handler)
+	router.HandleFunc("/fizz", handler)
+	router.HandleFunc("/buzz", handler)
+
+	request, _ := http.NewRequest("GET", "/buzz", nil)
+	for i := 0; i < b.N; i++ {
+		router.ServeHTTP(nil, request)
+	}
+}
+
+func BenchmarkMuxGorilla(b *testing.B) {
+	router := new(Router)
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	router.HandleFunc("/foo", handler)
+	router.HandleFunc("/bar", handler)
+	router.HandleFunc("/fizz", handler)
+	router.HandleFunc("/buzz", handler)
+
+	request, _ := http.NewRequest("GET", "/buzz", nil)
+	for i := 0; i < b.N; i++ {
+		router.ServeHTTP(nil, request)
+	}
+}
+
+func BenchmarkMuxGorillaSkipClean(b *testing.B) {
+	router := new(Router)
+	router.SkipClean(true)
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	router.HandleFunc("/foo", handler)
+	router.HandleFunc("/bar", handler)
+	router.HandleFunc("/fizz", handler)
+	router.HandleFunc("/buzz", handler)
+
+	request, _ := http.NewRequest("GET", "/buzz", nil)
+	for i := 0; i < b.N; i++ {
+		router.ServeHTTP(nil, request)
+	}
+}
+
+func BenchmarkMux5Middleware(b *testing.B) {
+	router := new(Router)
+	router.SkipClean(true)
+	middleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		})
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	for i := 0; i <= 5; i++ {
+		router.Use(middleware)
+	}
+	router.HandleFunc("/foo", handler)
+	router.HandleFunc("/bar", handler)
+	router.HandleFunc("/fizz", handler)
+	router.HandleFunc("/buzz", handler)
+
+	request, _ := http.NewRequest("GET", "/buzz", nil)
+	for i := 0; i < b.N; i++ {
+		router.ServeHTTP(nil, request)
+	}
+}
+
+func BenchmarkMux20Middleware(b *testing.B) {
+	router := new(Router)
+	router.SkipClean(true)
+	middleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		})
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	for i := 0; i <= 20; i++ {
+		router.Use(middleware)
+	}
+	router.HandleFunc("/foo", handler)
+	router.HandleFunc("/bar", handler)
+	router.HandleFunc("/fizz", handler)
+	router.HandleFunc("/buzz", handler)
+
+	request, _ := http.NewRequest("GET", "/buzz", nil)
 	for i := 0; i < b.N; i++ {
 		router.ServeHTTP(nil, request)
 	}
@@ -41,6 +132,21 @@ func BenchmarkManyPathVariables(b *testing.B) {
 
 	matchingRequest, _ := http.NewRequest("GET", "/v1/1/2/3/4/5", nil)
 	notMatchingRequest, _ := http.NewRequest("GET", "/v1/1/2/3/4", nil)
+	recorder := httptest.NewRecorder()
+	for i := 0; i < b.N; i++ {
+		router.ServeHTTP(nil, matchingRequest)
+		router.ServeHTTP(recorder, notMatchingRequest)
+	}
+}
+
+func BenchmarkManyPathVariablesLong(b *testing.B) {
+	router := new(Router)
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	lorem := "Lorem_ipsum_dolor_sit_amet,_consectetur_adipiscing_elit_sed_do_eiusmod_tempor_incididunt_ut_labore_et_dolore_magna_aliqua"
+	router.HandleFunc("/v1/{v1}/{v2}/{v3}/{v4}/{v5}", handler)
+
+	matchingRequest, _ := http.NewRequest("GET", fmt.Sprintf("/v1/%[1]s/%[1]s/%[1]s/%[1]s/%[1]s", lorem), nil)
+	notMatchingRequest, _ := http.NewRequest("GET", fmt.Sprintf("/v1/%[1]s/%[1]s/%[1]s/%[1]s", lorem), nil)
 	recorder := httptest.NewRecorder()
 	for i := 0; i < b.N; i++ {
 		router.ServeHTTP(nil, matchingRequest)


### PR DESCRIPTION
**Summary of Changes**

Added some additional benchmarks to make it easier to compare agains the standard library's `ServeMux`, and the effect of adding different matchers/middleware. 

Test plan:
```
go test -bench=.
```

Output:

```
goos: linux
goarch: amd64
pkg: github.com/gorilla/mux
cpu: Intel Xeon Processor (Skylake)
BenchmarkMux-32                           648987              1824 ns/op
BenchmarkMuxGoStd-32                    10531134               121.0 ns/op
BenchmarkMuxGorilla-32                    855477              1404 ns/op
BenchmarkMuxGorillaSkipClean-32           850012              1349 ns/op
BenchmarkMux5Middleware-32                640548              1777 ns/op
BenchmarkMux20Middleware-32               354134              2898 ns/op
BenchmarkMuxAlternativeInRegexp-32        379624              2943 ns/op
BenchmarkManyPathVariables-32             445899              2714 ns/op
BenchmarkManyPathVariablesLong-32          21291             53190 ns/op
Benchmark_findQueryKey/0-32              4871636               238.9 ns/op             0 B/op          0 allocs/op
Benchmark_findQueryKey/1-32              3438940               337.7 ns/op            40 B/op          3 allocs/op
Benchmark_findQueryKey/2-32               907651              1272 ns/op             483 B/op         10 allocs/op
Benchmark_findQueryKey/3-32               811803              1353 ns/op             543 B/op         11 allocs/op
Benchmark_findQueryKey/4-32             201771504                6.183 ns/op           0 B/op          0 allocs/op
Benchmark_findQueryKeyGoLib/0-32          859398              1195 ns/op             864 B/op          8 allocs/op
Benchmark_findQueryKeyGoLib/1-32         1930530               600.8 ns/op           432 B/op          4 allocs/op
Benchmark_findQueryKeyGoLib/2-32          322654              3732 ns/op            1542 B/op         24 allocs/op
Benchmark_findQueryKeyGoLib/3-32          241390              4794 ns/op            1984 B/op         28 allocs/op
Benchmark_findQueryKeyGoLib/4-32        211411327                5.503 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/gorilla/mux  28.404s
```
