### PR TITLE
drop the versions of go that are no longer supported + add 1.18 to ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,4 +67,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ["latest", "1.15", "1.14", "1.13", "1.12", "1.11"]
+              version: ["1.18", "1.17", "1.16"]


### PR DESCRIPTION
Fixes #

**Summary of Changes**

drop go versions that are no longer supported + add 1.18
