### PR TITLE
Fix `authenticationMiddleware` initialization in the `README.md` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ func (amw *authenticationMiddleware) Middleware(next http.Handler) http.Handler 
 r := mux.NewRouter()
 r.HandleFunc("/", handler)
 
-amw := authenticationMiddleware{}
+amw := authenticationMiddleware{tokenUsers: make(map[string]string)}
 amw.Populate()
 
 r.Use(amw.Middleware)


### PR DESCRIPTION
Fixes #692 

**Summary of Changes**

1. Fix the `README.md` middleware section. An example is demonstrated about the `authenticationMiddleware` and `authenticationMiddleware` initialization is incorrect because incorrect initialization in real-world code throws a panic runtime error.  The correct way of initialization is 
```golang
amw := authenticationMiddleware{make(map[string]string)}
```
and this PR fixes that. No test cases are required in this case because in the example file it is already written correctly 
https://github.com/gorilla/mux/blob/master/example_authentication_middleware_test.go#L43

> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!
