### PR TITLE
Additional documentation for func Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ r.PathPrefix("/products/")
 
 ```go
 r.Methods("GET", "POST")
+// This is equivalent to .Methods("GET")
+r.Methods("GET", "POST").Methods("GET")
 ```
 
 ...or URL schemes:

--- a/doc.go
+++ b/doc.go
@@ -81,6 +81,8 @@ There are several other matchers that can be added. To match path prefixes:
 ...or HTTP methods:
 
 	r.Methods("GET", "POST")
+	// This is equivalent to .Methods("GET")
+	r.Methods("GET", "POST").Methods("GET")
 
 ...or URL schemes:
 

--- a/route.go
+++ b/route.go
@@ -322,6 +322,10 @@ func (m methodMatcher) Match(r *http.Request, match *RouteMatch) bool {
 // Methods adds a matcher for HTTP methods.
 // It accepts a sequence of one or more methods to be matched, e.g.:
 // "GET", "POST", "PUT".
+//
+// NOTE: Chaining multiple Methods will result in the last added
+// Methods will override the allowed methods specified by the
+// previously Methods calls.
 func (r *Route) Methods(methods ...string) *Route {
 	for k, v := range methods {
 		methods[k] = strings.ToUpper(v)


### PR DESCRIPTION
Reading through #694 it sounds like that the behaviour of chaining multiple `func Methods(methods ...string)`is not clear. This PR is not a fix to this issue but it attempts to help make this behaviour more clear to other/new users.

**Summary of Changes**

1. A small note to `func Methods(methods ...string)` that explains the behavior of chaining multiple `Methods`.
2. Updated the methods section in the README