### PR TITLE
Add RegexpCompileFunc to override regexp.Compile

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -19,6 +19,10 @@ var (
 	ErrMethodMismatch = errors.New("method is not allowed")
 	// ErrNotFound is returned when no route match is found.
 	ErrNotFound = errors.New("no matching route was found")
+	// RegexpCompileFunc aliases regexp.Compile and enables overriding it.
+	// Do not run this function from `init()` in importable packages.
+	// Changing this value is not safe for concurrent use.
+	RegexpCompileFunc = regexp.Compile
 )
 
 // NewRouter returns a new router instance.
@@ -524,7 +528,7 @@ func mapFromPairsToRegex(pairs ...string) (map[string]*regexp.Regexp, error) {
 	}
 	m := make(map[string]*regexp.Regexp, length/2)
 	for i := 0; i < length; i += 2 {
-		regex, err := regexp.Compile(pairs[i+1])
+		regex, err := RegexpCompileFunc(pairs[i+1])
 		if err != nil {
 			return nil, err
 		}

--- a/regexp.go
+++ b/regexp.go
@@ -93,7 +93,7 @@ func newRouteRegexp(tpl string, typ regexpType, options routeRegexpOptions) (*ro
 
 		// Append variable name and compiled pattern.
 		varsN[i/2] = name
-		varsR[i/2], err = regexp.Compile(fmt.Sprintf("^%s$", patt))
+		varsR[i/2], err = RegexpCompileFunc(fmt.Sprintf("^%s$", patt))
 		if err != nil {
 			return nil, err
 		}
@@ -125,7 +125,7 @@ func newRouteRegexp(tpl string, typ regexpType, options routeRegexpOptions) (*ro
 		reverse.WriteByte('/')
 	}
 	// Compile full regexp.
-	reg, errCompile := regexp.Compile(pattern.String())
+	reg, errCompile := RegexpCompileFunc(pattern.String())
 	if errCompile != nil {
 		return nil, errCompile
 	}

--- a/route_test.go
+++ b/route_test.go
@@ -57,7 +57,7 @@ func BenchmarkNewRouterRegexpFunc(b *testing.B) {
 	}
 }
 
-func testNewRouter(tb testing.TB, handler http.Handler) {
+func testNewRouter(_ testing.TB, handler http.Handler) {
 	r := NewRouter()
 	// A route with a route variable:
 	r.Handle("/metrics/{type}", handler)

--- a/route_test.go
+++ b/route_test.go
@@ -1,0 +1,66 @@
+package mux
+
+import (
+	"net/http"
+	"regexp"
+	"sync"
+	"testing"
+)
+
+var testNewRouterMu sync.Mutex
+var testHandler = http.NotFoundHandler()
+
+func BenchmarkNewRouter(b *testing.B) {
+	testNewRouterMu.Lock()
+	defer testNewRouterMu.Unlock()
+
+	// Set the RegexpCompileFunc to the default regexp.Compile.
+	RegexpCompileFunc = regexp.Compile
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		testNewRouter(b, testHandler)
+	}
+}
+
+func BenchmarkNewRouterRegexpFunc(b *testing.B) {
+	testNewRouterMu.Lock()
+	defer testNewRouterMu.Unlock()
+
+	// We preallocate the size to 8.
+	cache := make(map[string]*regexp.Regexp, 8)
+
+	// Override the RegexpCompileFunc to reuse compiled expressions
+	// from the `cache` map. Real world caches should have eviction
+	// policies or some sort of approach to limit memory use.
+	RegexpCompileFunc = func(expr string) (*regexp.Regexp, error) {
+		if regex, ok := cache[expr]; ok {
+			return regex, nil
+		}
+
+		regex, err := regexp.Compile(expr)
+		if err != nil {
+			return nil, err
+		}
+
+		cache[expr] = regex
+		return regex, nil
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		testNewRouter(b, testHandler)
+	}
+}
+
+func testNewRouter(tb testing.TB, handler http.Handler) {
+	r := NewRouter()
+	// A route with a route variable:
+	r.Handle("/metrics/{type}", handler)
+	r.Queries("orgID", "{orgID:[0-9]*?}")
+	r.Host("{subdomain}.domain.com")
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Route creation is slow as it always invokes regexp.Compile, increasing memory and cpu pressure in cases where route creation is common (e.g. an api gateway reloading changes). This PR adds a exported `RegexpCompileFunc` variable, that's possible to override with other implementations, adding caches. Added a benchmark.

## Related Tickets & Documents

```
# go test -bench=NewRouter -benchmem -memprofile memprofile.out -cpuprofile profile.out -count 10
goos: linux
goarch: amd64
pkg: github.com/gorilla/mux
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkNewRouter-8             	   36786	     34450 ns/op	   26327 B/op	     374 allocs/op
BenchmarkNewRouter-8             	   44839	     31840 ns/op	   26327 B/op	     374 allocs/op
BenchmarkNewRouter-8             	   48939	     23419 ns/op	   26327 B/op	     374 allocs/op
BenchmarkNewRouter-8             	   52255	     25949 ns/op	   26327 B/op	     374 allocs/op
BenchmarkNewRouter-8             	   44684	     23150 ns/op	   26329 B/op	     374 allocs/op
BenchmarkNewRouter-8             	   41522	     35047 ns/op	   26328 B/op	     374 allocs/op
BenchmarkNewRouter-8             	   48354	     35461 ns/op	   26329 B/op	     374 allocs/op
BenchmarkNewRouter-8             	   33850	     38467 ns/op	   26330 B/op	     374 allocs/op
BenchmarkNewRouter-8             	   36920	     33917 ns/op	   26330 B/op	     374 allocs/op
BenchmarkNewRouter-8             	   40767	     29980 ns/op	   26329 B/op	     374 allocs/op
BenchmarkNewRouterRegexpFunc-8   	  303121	      3738 ns/op	    2161 B/op	      73 allocs/op
BenchmarkNewRouterRegexpFunc-8   	  311847	      4184 ns/op	    2161 B/op	      73 allocs/op
BenchmarkNewRouterRegexpFunc-8   	  300144	      4212 ns/op	    2161 B/op	      73 allocs/op
BenchmarkNewRouterRegexpFunc-8   	  329636	      4528 ns/op	    2161 B/op	      73 allocs/op
BenchmarkNewRouterRegexpFunc-8   	  277980	      5136 ns/op	    2161 B/op	      73 allocs/op
BenchmarkNewRouterRegexpFunc-8   	  363416	      4578 ns/op	    2161 B/op	      73 allocs/op
BenchmarkNewRouterRegexpFunc-8   	  328996	      4231 ns/op	    2161 B/op	      73 allocs/op
BenchmarkNewRouterRegexpFunc-8   	  327628	      3699 ns/op	    2161 B/op	      73 allocs/op
BenchmarkNewRouterRegexpFunc-8   	  300370	      3955 ns/op	    2161 B/op	      73 allocs/op
BenchmarkNewRouterRegexpFunc-8   	  297345	      4115 ns/op	    2161 B/op	      73 allocs/op
PASS
ok  	github.com/gorilla/mux	35.091s
```

Benchmark: NewRouter

Average runtime per iteration: ~34450 ns/op
Average memory usage per iteration: ~26327 B/op
Average allocations per iteration: ~374 allocs/op

Benchmark: NewRouterRegexpFunc

Average runtime per iteration: ~4184 ns/op (approx. 87.8% improvement)
Average memory usage per iteration: ~2161 B/op (approx. 91.8% reduction)
Average allocations per iteration: ~73 allocs/op (approx. 80.5% reduction)

As per go doc, [using *regexp.Regexp concurrently is safe](https://pkg.go.dev/regexp#Regexp).

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [ ] `make verify` is passing
- [x] `make test` is passing
