### PR TITLE
Optimize/new route regexp allocations

### DIFF
--- a/regexp.go
+++ b/regexp.go
@@ -80,7 +80,9 @@ func newRouteRegexp(tpl string, typ regexpType, options routeRegexpOptions) (*ro
 		end = idxs[i+1]
 		tag := tpl[idxs[i]:end]
 
-		param = tpl[idxs[i]+1 : end-1]
+		// trim braces from tag
+		param = tag[1 : len(tag)-1]
+
 		colonIdx = strings.Index(param, ":")
 		if colonIdx == -1 {
 			name = param
@@ -88,9 +90,6 @@ func newRouteRegexp(tpl string, typ regexpType, options routeRegexpOptions) (*ro
 		} else {
 			name = param[0:colonIdx]
 			patt = param[colonIdx+1:]
-		}
-		if patt == "" {
-			patt = defaultPattern
 		}
 
 		// Name or pattern can't be empty.

--- a/regexp.go
+++ b/regexp.go
@@ -74,10 +74,11 @@ func newRouteRegexp(tpl string, typ regexpType, options routeRegexpOptions) (*ro
 	var patt, param, name string
 	for i := 0; i < len(idxs); i += 2 {
 		// Set all values we are interested in.
-		groupIdx = i/2
+		groupIdx = i / 2
 
 		raw := tpl[end:idxs[i]]
 		end = idxs[i+1]
+		tag := tpl[idxs[i]:end]
 
 		param = tpl[idxs[i]+1 : end-1]
 		colonIdx = strings.Index(param, ":")
@@ -94,21 +95,21 @@ func newRouteRegexp(tpl string, typ regexpType, options routeRegexpOptions) (*ro
 
 		// Name or pattern can't be empty.
 		if name == "" || patt == "" {
-			return nil, fmt.Errorf("mux: missing name or pattern in %q", param)
+			return nil, fmt.Errorf("mux: missing name or pattern in %q", tag)
 		}
 		// Build the regexp pattern.
 		groupName := varGroupName(groupIdx)
 
-		pattern.WriteString(regexp.QuoteMeta(raw)+"(?P<" + groupName + ">" + patt + ")")
+		pattern.WriteString(regexp.QuoteMeta(raw) + "(?P<" + groupName + ">" + patt + ")")
 
 		// Build the reverse template.
-		reverse.WriteString(raw+"%s")
+		reverse.WriteString(raw + "%s")
 
 		// Append variable name and compiled pattern.
 		varsN[groupIdx] = name
 		varsR[groupIdx], err = RegexpCompileFunc("^" + patt + "$")
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("mux: error compiling regex for %q: %w", tag, err)
 		}
 	}
 	// Add the remaining.

--- a/regexp.go
+++ b/regexp.go
@@ -114,18 +114,15 @@ func newRouteRegexp(tpl string, typ regexpType, options routeRegexpOptions) (*ro
 	// Add the remaining.
 	raw := tpl[end:]
 	pattern.WriteString(regexp.QuoteMeta(raw))
-
 	if options.strictSlash {
 		pattern.WriteString("[/]?")
 	}
-
 	if typ == regexpTypeQuery {
 		// Add the default pattern if the query value is empty
 		if queryVal := strings.SplitN(template, "=", 2)[1]; queryVal == "" {
 			pattern.WriteString(defaultPattern)
 		}
 	}
-
 	if typ != regexpTypePrefix {
 		pattern.WriteByte('$')
 	}
@@ -138,9 +135,7 @@ func newRouteRegexp(tpl string, typ regexpType, options routeRegexpOptions) (*ro
 			wildcardHostPort = true
 		}
 	}
-
 	reverse.WriteString(raw)
-
 	if endSlash {
 		reverse.WriteByte('/')
 	}

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -13,6 +13,8 @@ func Test_newRouteRegexp_Errors(t *testing.T) {
 		in, out string
 	}{
 		{"/{}", `mux: missing name or pattern in "{}"`},
+		{"/{:.}", `mux: missing name or pattern in "{:.}"`},
+		{"/{a:}", `mux: missing name or pattern in "{a:}"`},
 		{"/{id:abc(}", `mux: error compiling regex for "{id:abc(}":`},
 	}
 

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -4,8 +4,32 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 )
+
+func Test_newRouteRegexp_Errors(t *testing.T) {
+	tests := []struct {
+		in, out string
+	}{
+		{"/{}", `mux: missing name or pattern in "{}"`},
+		{"/{id:abc(}", `mux: error compiling regex for "{id:abc(}":`},
+	}
+
+	for _, tc := range tests {
+		t.Run("Test case for "+tc.in, func(t *testing.T) {
+			_, err := newRouteRegexp(tc.in, 0, routeRegexpOptions{})
+			if err != nil {
+				if strings.HasPrefix(err.Error(), tc.out) {
+					return
+				}
+				t.Errorf("Resulting error does not contain %q as expected, error: %s", tc.out, err)
+			} else {
+				t.Error("Expected error, got nil")
+			}
+		})
+	}
+}
 
 func Test_findFirstQueryKey(t *testing.T) {
 	tests := []string{


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This optimizes NewRouter creation. The change introduces strings.Builder for more efficient strings concatenation, and replaces SplitN with Index, avoiding the allocations for the slice.

## Related Tickets & Documents

| Test Group                  | Condition | Average Time (ns/op) | Average Memory (B/op) | Average Allocations |
|-----------------------------|-----------|----------------------|-----------------------|---------------------|
| **BenchmarkNewRouter**      | Before    | 37041                | 26553                  | 376                 |
|                             | After     | 32046                | 25800                  | 347                 |
| **BenchmarkNewRouterRegexpFunc** | Before | 4713                 | 2385                   | 75                  |
|                             | After     | 2792                 | 1640                   | 46                  |


BenchmarkNewRouterRegexpFunc:

Time Improvement: Significant improvement in execution time from 4,713 ns/op to 2,792 ns/op.
Memory Usage: Memory usage per operation dropped from 2,385 bytes to 1,640 bytes.
Allocations: Allocations per operation decreased substantially from 75 to 46.

## Added/updated tests?

- [x] Yes

## Run verifications and test

- [ ] `make verify` is passing
- [x] `make test` is passing
