### PR TITLE
Use "redirect" rather than "re-direct" in docs

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -233,8 +233,8 @@ func (r *Router) GetRoute(name string) *Route {
 // When false, if the route path is "/path", accessing "/path/" will not match
 // this route and vice versa.
 //
-// The re-direct is a HTTP 301 (Moved Permanently). Note that when this is set for
-// routes with a non-idempotent method (e.g. POST, PUT), the subsequent re-directed
+// The redirect is a HTTP 301 (Moved Permanently). Note that when this is set for
+// routes with a non-idempotent method (e.g. POST, PUT), the subsequent redirected
 // request will be made as a GET by most clients. Use middleware or client settings
 // to modify this behaviour as needed.
 //


### PR DESCRIPTION
This brings these docs in line with the rest of the repository.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

Remove use of hyphen in "redirect" in the documentation.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: No regression test required 
- [ ] I need help with writing tests

## Run verifications and test

- [ ] `make verify` is passing
- [x] `make test` is passing

`make verify` is not passing for me locally, but the failures are in unrelated
files. It may be because I don't see a .golangci.yml in the repo. I assume it's
using my linting config instead.
