### PR TITLE
Revert LICENSE endorsement term

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -10,7 +10,7 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-	 * Neither the name of Google Inc. nor the names of its
+	 * Neither the name of the copyright owner nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 


### PR DESCRIPTION
The license used to read "the copyright owner", rather than Google Inc. 

This was probably changed by mistake in #723
