### PR TITLE
Feature route middleware with `.Use`

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -32,6 +32,19 @@ func (r *Router) useInterface(mw middleware) {
 	r.middlewares = append(r.middlewares, mw)
 }
 
+// RouteMiddleware -------------------------------------------------------------
+
+func (r *Route) Use(mwf ...MiddlewareFunc) {
+	for _, fn := range mwf {
+		r.middlewares = append(r.middlewares, fn)
+	}
+}
+
+// useInterface appends a middleware to the chain. Middleware can be used to intercept or otherwise modify requests and/or responses, and are executed in the order that they are applied to the Router.
+func (r *Route) useInterface(mw middleware) {
+	r.middlewares = append(r.middlewares, mw)
+}
+
 // CORSMethodMiddleware automatically sets the Access-Control-Allow-Methods response header
 // on requests for routes that have an OPTIONS method matcher to all the method matchers on
 // the route. Routes that do not explicitly handle OPTIONS requests will not be processed

--- a/middleware.go
+++ b/middleware.go
@@ -34,10 +34,12 @@ func (r *Router) useInterface(mw middleware) {
 
 // RouteMiddleware -------------------------------------------------------------
 
-func (r *Route) Use(mwf ...MiddlewareFunc) {
+func (r *Route) Use(mwf ...MiddlewareFunc) *Route {
 	for _, fn := range mwf {
 		r.middlewares = append(r.middlewares, fn)
 	}
+
+	return r
 }
 
 // useInterface appends a middleware to the chain. Middleware can be used to intercept or otherwise modify requests and/or responses, and are executed in the order that they are applied to the Router.

--- a/middleware.go
+++ b/middleware.go
@@ -34,6 +34,7 @@ func (r *Router) useInterface(mw middleware) {
 
 // RouteMiddleware -------------------------------------------------------------
 
+// Use appends a MiddlewareFunc to the chain. Middleware can be used to intercept or otherwise modify requests and/or responses, and are executed in the order that they are applied to the Route. Route middleware are executed after the Router middleware but before the Route handler.
 func (r *Route) Use(mwf ...MiddlewareFunc) *Route {
 	for _, fn := range mwf {
 		r.middlewares = append(r.middlewares, fn)
@@ -42,7 +43,7 @@ func (r *Route) Use(mwf ...MiddlewareFunc) *Route {
 	return r
 }
 
-// useInterface appends a middleware to the chain. Middleware can be used to intercept or otherwise modify requests and/or responses, and are executed in the order that they are applied to the Router.
+// useInterface appends a MiddlewareFunc to the chain. Middleware can be used to intercept or otherwise modify requests and/or responses, and are executed in the order that they are applied to the Route. Route middleware are executed after the Router middleware but before the Route handler.
 func (r *Route) useInterface(mw middleware) {
 	r.middlewares = append(r.middlewares, mw)
 }

--- a/route.go
+++ b/route.go
@@ -102,8 +102,8 @@ func (r *Route) Match(req *http.Request, match *RouteMatch) bool {
 		match.Route = r
 	}
 	if match.Handler == nil {
-		// for the matched handler, wrap it in the assigned middleware
-		match.Handler = r.WrapHandlerInMiddleware(r.handler)
+		// for the matched handler, wrap it in the assigned middlewares
+		match.Handler = r.WrapHandlerInMiddlewares(r.handler)
 	}
 
 	// Set variables.
@@ -146,10 +146,9 @@ func (r *Route) GetHandler() http.Handler {
 	return r.handler
 }
 
-// WrapHandlerInMiddleware wraps the supplied handler in the middleware
-// that were assigned to this route. If no middleware specified
-// the handler is returned
-func (r *Route) WrapHandlerInMiddleware(handler http.Handler) http.Handler {
+// WrapHandlerInMiddleware wraps the route handler in the assigned middlewares.
+// If no middlewares are specified, just the handler is returned.
+func (r *Route) WrapHandlerInMiddlewares(handler http.Handler) http.Handler {
 	if len(r.middlewares) > 0 {
 		for i := len(r.middlewares) - 1; i >= 0; i-- {
 			handler = r.middlewares[i].Middleware(handler)

--- a/route.go
+++ b/route.go
@@ -102,8 +102,7 @@ func (r *Route) Match(req *http.Request, match *RouteMatch) bool {
 		match.Route = r
 	}
 	if match.Handler == nil {
-		// for the matched handler, wrap it in the assigned middlewares
-		match.Handler = r.WrapHandlerInMiddlewares(r.handler)
+		match.Handler = r.GetHandlerWithMiddlewares()
 	}
 
 	// Set variables.
@@ -146,10 +145,12 @@ func (r *Route) GetHandler() http.Handler {
 	return r.handler
 }
 
-// WrapHandlerInMiddleware wraps the route handler in the assigned middlewares.
-// If no middlewares are specified, just the handler is returned.
-func (r *Route) WrapHandlerInMiddlewares(handler http.Handler) http.Handler {
-	if len(r.middlewares) > 0 {
+// GetHandlerWithMiddleware returns the route handler wrapped in the assigned middlewares.
+// If no middlewares are specified, just the handler, if any, is returned.
+func (r *Route) GetHandlerWithMiddlewares() http.Handler {
+	handler := r.handler
+
+	if handler != nil && len(r.middlewares) > 0 {
 		for i := len(r.middlewares) - 1; i >= 0; i-- {
 			handler = r.middlewares[i].Middleware(handler)
 		}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description
Added support for route specific middleware using the `.Use` method.
Using the `.Use` method on `Route` middlewares can be set on a specific route.

Example:
```go
router.HandleFunc("/", handlerFunc).Use(middleware)
```

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why:
- [ ] I need help with writing tests

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing
