### PR TITLE
added case insensitive matcher for request methods

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"path"
 	"regexp"
+	"strings"
 )
 
 var (
@@ -102,6 +103,10 @@ type routeConf struct {
 	buildScheme string
 
 	buildVarsFunc BuildVarsFunc
+
+	// If true, methods will be matched case insensitive.
+	// The methodCaseInsensitiveMatcher will be used instead of methodMatcher
+	matchMethodCaseInsensitive bool
 }
 
 // returns an effective deep copy of `routeConf`
@@ -274,6 +279,12 @@ func (r *Router) SkipClean(value bool) *Router {
 // CurrentRoute will yield nil with this option.
 func (r *Router) OmitRouteFromContext(value bool) *Router {
 	r.omitRouteFromContext = value
+	return r
+}
+
+// MatchMethodCaseInsensitive defines the behaviour of ignoring casing for request methods.
+func (r *Router) MatchMethodCaseInsensitive(value bool) *Router {
+	r.matchMethodCaseInsensitive = value
 	return r
 }
 
@@ -578,6 +589,13 @@ func matchInArray(arr []string, value string) bool {
 		}
 	}
 	return false
+}
+
+func sliceToUpper(slice []string) []string {
+	for k, v := range slice {
+		slice[k] = strings.ToUpper(v)
+	}
+	return slice
 }
 
 // matchMapWithString returns true if the given key/value pairs exist in a given map.

--- a/mux_test.go
+++ b/mux_test.go
@@ -2069,6 +2069,85 @@ func TestNoMatchMethodErrorHandler(t *testing.T) {
 	}
 }
 
+func TestMethodMatchingCaseInsensitiveOnRoute(t *testing.T) {
+	func1 := func(w http.ResponseWriter, r *http.Request) {}
+
+	r := NewRouter()
+	r.HandleFunc("/", func1).Methods("get")
+
+	req, _ := http.NewRequest("get", "http://localhost/", nil)
+	match := new(RouteMatch)
+	matched := r.Match(req, match)
+
+	if matched {
+		t.Error("Should not have matched route for methods")
+	}
+
+	if match.MatchErr != ErrMethodMismatch {
+		t.Error("Should get ErrMethodMismatch error")
+	}
+
+	resp := NewRecorder()
+	r.ServeHTTP(resp, req)
+	if resp.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expecting code %v", 405)
+	}
+
+	// Add matching route
+	r.HandleFunc("/", func1).MethodsCaseInsensitive("GET")
+
+	match = new(RouteMatch)
+	matched = r.Match(req, match)
+
+	if !matched {
+		t.Error("Should have matched route")
+	}
+
+	if match.MatchErr != nil {
+		t.Error("Should not have any matching error. Found:", match.MatchErr)
+	}
+}
+
+func TestMethodMatchingCaseInsensitiveOnRouter(t *testing.T) {
+	func1 := func(w http.ResponseWriter, r *http.Request) {}
+
+	r := NewRouter()
+	r.HandleFunc("/", func1).Methods("get")
+
+	req, _ := http.NewRequest("get", "http://localhost/", nil)
+	match := new(RouteMatch)
+	matched := r.Match(req, match)
+
+	if matched {
+		t.Error("Should not have matched route for methods")
+	}
+
+	if match.MatchErr != ErrMethodMismatch {
+		t.Error("Should get ErrMethodMismatch error")
+	}
+
+	resp := NewRecorder()
+	r.ServeHTTP(resp, req)
+	if resp.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expecting code %v", 405)
+	}
+
+	r.MatchMethodCaseInsensitive(true)
+	r.HandleFunc("/a", func1).Methods("get")
+	req, _ = http.NewRequest("get", "http://localhost/a", nil)
+
+	match = new(RouteMatch)
+	matched = r.Match(req, match)
+
+	if !matched {
+		t.Error("Should have matched route")
+	}
+
+	if match.MatchErr != nil {
+		t.Error("Should not have any matching error. Found:", match.MatchErr)
+	}
+}
+
 func TestMultipleDefinitionOfSamePathWithDifferentMethods(t *testing.T) {
 	emptyHandler := func(w http.ResponseWriter, r *http.Request) {}
 


### PR DESCRIPTION
# Ignore this PR.. is replaced by #764

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description
This PR adds the ability to define case insensitive method matching for routes. as suggested in issue #762.
To achieve this this pr adds the following:
```GO
type methodCaseInsensitiveMatcher []string

func (r *Route) MethodsCaseInsensitive(methods ...string) *Route
func (r *Route) MethodsCaseSensitive(methods ...string) *Route
func (r *Route) MatchMethodCaseInsensitive(value bool) *Route

func (r *Router) MatchMethodCaseInsensitive(value bool) *Router

type routeConf struct {
    ...
    // If true, methods will be matched case insensitive.
    // The methodCaseInsensitiveMatcher will be used instead of methodMatcher
    matchMethodCaseInsensitive bool
}

// as well a the helper
func sliceToUpper(slice []string) []string 
```
### Usage
Setting ```matchMethodCaseInsensitive``` to ```true``` all routes defined after will end up getting the ```methodCaseInsensitiveMatcher``` instead of the default ```methodMatcher```. 

Enabling insesitivity for a single route can be done in one of the following ways:
```GO
r.HandleFunc("/", func).MatchMethodCaseInsensitive(true).Methods("GET")
// Not the prefferd method, order of opperations is critcal here. 
// Since the Methods(...) func adds the matcher. 
// Invoking the MatchMethodCaseInsensitive(true) method after it will have no effect.

r.HandleFunc("/", func).MethodsCaseInsensitive("GET")
// Explicitly match the methods for this route without case sensitivity
```
If ```methodCaseInsensitiveMatcher``` on the router is set to true, disabling it for a specific route can be done like:
```GO
r.HandleFunc("/", func).MethodsCaseSensitive("GET")
// Explicitly match the methods for this route with case sensitivity
```

In all other cases the ```Methods(...)``` func will add the appropriate matcher based on the value of the ```routeConf``` option ```methodCaseInsensitiveMatcher```

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #762 
- Closes #762 

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing
