### PR TITLE
Feature/method case insensitive

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -29,7 +29,12 @@ var (
 
 // NewRouter returns a new router instance.
 func NewRouter() *Router {
-	return &Router{namedRoutes: make(map[string]*Route)}
+	return &Router{
+		namedRoutes: make(map[string]*Route),
+		routeConf: routeConf{
+			methodMatcher: methodDefaultMatcher{},
+		},
+	}
 }
 
 // Router registers routes to be matched and dispatches a handler.
@@ -104,9 +109,8 @@ type routeConf struct {
 
 	buildVarsFunc BuildVarsFunc
 
-	// If true, methods will be matched case insensitive.
-	// The methodCaseInsensitiveMatcher will be used instead of methodMatcher
-	matchMethodCaseInsensitive bool
+	// Holds the default method matcher
+	methodMatcher matcher
 }
 
 // returns an effective deep copy of `routeConf`
@@ -282,12 +286,6 @@ func (r *Router) OmitRouteFromContext(value bool) *Router {
 	return r
 }
 
-// MatchMethodCaseInsensitive defines the behaviour of ignoring casing for request methods.
-func (r *Router) MatchMethodCaseInsensitive(value bool) *Router {
-	r.matchMethodCaseInsensitive = value
-	return r
-}
-
 // UseEncodedPath tells the router to match the encoded original path
 // to the routes.
 // For eg. "/path/foo%2Fbar/to" will match the path "/path/{var}/to".
@@ -296,6 +294,24 @@ func (r *Router) MatchMethodCaseInsensitive(value bool) *Router {
 // For eg. "/path/foo%2Fbar/to" will match the path "/path/foo/bar/to"
 func (r *Router) UseEncodedPath() *Router {
 	r.useEncodedPath = true
+	return r
+}
+
+// MatchMethodCaseInsensitive defines the behaviour of ignoring casing for request methods.
+func (r *Router) MatchMethodDefault() *Router {
+	r.methodMatcher = methodDefaultMatcher{}
+	return r
+}
+
+// MatchMethodCaseInsensitive defines the behaviour of ignoring casing for request methods.
+func (r *Router) MatchMethodCaseInsensitive() *Router {
+	r.methodMatcher = methodCaseInsensitiveMatcher{}
+	return r
+}
+
+// MatchMethodExact defines the behaviour of matching exact request methods.
+func (r *Router) MatchMethodExact() *Router {
+	r.methodMatcher = methodCaseExactMatcher{}
 	return r
 }
 

--- a/mux.go
+++ b/mux.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"path"
 	"regexp"
+	"strings"
 )
 
 var (
@@ -102,6 +103,10 @@ type routeConf struct {
 	buildScheme string
 
 	buildVarsFunc BuildVarsFunc
+
+	// If true, methods will be matched case insensitive.
+	// The methodCaseInsensitiveMatcher will be used instead of methodMatcher
+	matchMethodCaseInsensitive bool
 }
 
 // returns an effective deep copy of `routeConf`
@@ -274,6 +279,12 @@ func (r *Router) SkipClean(value bool) *Router {
 // CurrentRoute will yield nil with this option.
 func (r *Router) OmitRouteFromContext(value bool) *Router {
 	r.omitRouteFromContext = value
+	return r
+}
+
+// MatchMethodCaseInsensitive defines the behaviour of ignoring casing for request methods.
+func (r *Router) MatchMethodCaseInsensitive(value bool) *Router {
+	r.matchMethodCaseInsensitive = value
 	return r
 }
 
@@ -578,6 +589,13 @@ func matchInArray(arr []string, value string) bool {
 		}
 	}
 	return false
+}
+
+func sliceToUpper(slice []string) []string {
+	for k, v := range slice {
+		slice[k] = strings.ToUpper(v)
+	}
+	return slice
 }
 
 // matchMapWithString returns true if the given key/value pairs exist in a given map.

--- a/mux_test.go
+++ b/mux_test.go
@@ -2069,6 +2069,85 @@ func TestNoMatchMethodErrorHandler(t *testing.T) {
 	}
 }
 
+func TestMethodMatchingCaseInsensitiveOnRoute(t *testing.T) {
+	func1 := func(w http.ResponseWriter, r *http.Request) {}
+
+	r := NewRouter()
+	r.HandleFunc("/", func1).Methods("get")
+
+	req, _ := http.NewRequest("get", "http://localhost/", nil)
+	match := new(RouteMatch)
+	matched := r.Match(req, match)
+
+	if matched {
+		t.Error("Should not have matched route for methods")
+	}
+
+	if match.MatchErr != ErrMethodMismatch {
+		t.Error("Should get ErrMethodMismatch error")
+	}
+
+	resp := NewRecorder()
+	r.ServeHTTP(resp, req)
+	if resp.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expecting code %v", 405)
+	}
+
+	// Add matching route
+	r.HandleFunc("/", func1).MethodsCaseInsensitive("GET")
+
+	match = new(RouteMatch)
+	matched = r.Match(req, match)
+
+	if !matched {
+		t.Error("Should have matched route")
+	}
+
+	if match.MatchErr != nil {
+		t.Error("Should not have any matching error. Found:", match.MatchErr)
+	}
+}
+
+func TestMethodMatchingCaseInsensitiveOnRouter(t *testing.T) {
+	func1 := func(w http.ResponseWriter, r *http.Request) {}
+
+	r := NewRouter()
+	r.HandleFunc("/", func1).Methods("get")
+
+	req, _ := http.NewRequest("get", "http://localhost/", nil)
+	match := new(RouteMatch)
+	matched := r.Match(req, match)
+
+	if matched {
+		t.Error("Should not have matched route for methods")
+	}
+
+	if match.MatchErr != ErrMethodMismatch {
+		t.Error("Should get ErrMethodMismatch error")
+	}
+
+	resp := NewRecorder()
+	r.ServeHTTP(resp, req)
+	if resp.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expecting code %v", 405)
+	}
+
+	r.MatchMethodCaseInsensitive(true)
+	r.HandleFunc("/a", func1).Methods("get")
+	req, _ = http.NewRequest("get", "http://localhost/a", nil)
+
+	match = new(RouteMatch)
+	matched = r.Match(req, match)
+
+	if !matched {
+		t.Error("Should have matched route")
+	}
+
+	if match.MatchErr != nil {
+		t.Error("Should not have any matching error. Found:", match.MatchErr)
+	}
+}
+
 func TestMultipleDefinitionOfSamePathWithDifferentMethods(t *testing.T) {
 	emptyHandler := func(w http.ResponseWriter, r *http.Request) {}
 

--- a/old_test.go
+++ b/old_test.go
@@ -281,29 +281,29 @@ var hostMatcherTests = []hostMatcherTest{
 }
 
 type methodMatcherTest struct {
-	matcher methodMatcher
+	matcher methodDefaultMatcher
 	method  string
 	result  bool
 }
 
 var methodMatcherTests = []methodMatcherTest{
 	{
-		matcher: methodMatcher([]string{"GET", "POST", "PUT"}),
+		matcher: ([]string{"GET", "POST", "PUT"}),
 		method:  "GET",
 		result:  true,
 	},
 	{
-		matcher: methodMatcher([]string{"GET", "POST", "PUT"}),
+		matcher: methodDefaultMatcher([]string{"GET", "POST", "PUT"}),
 		method:  "POST",
 		result:  true,
 	},
 	{
-		matcher: methodMatcher([]string{"GET", "POST", "PUT"}),
+		matcher: methodDefaultMatcher([]string{"GET", "POST", "PUT"}),
 		method:  "PUT",
 		result:  true,
 	},
 	{
-		matcher: methodMatcher([]string{"GET", "POST", "PUT"}),
+		matcher: methodDefaultMatcher([]string{"GET", "POST", "PUT"}),
 		method:  "DELETE",
 		result:  false,
 	},


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description
This PR adds the ability to define case insensitive method matching for routes. as suggested in issue #762.
To achieve this this pr adds the following:
```GO
// methodMatcher matches the request against HTTP methods without case sensitivity.
// Both the supplied methods as well as the request method will be transformed to uppercase.
type methodCaseInsensitiveMatcher []string

// methodCaseExactMatcher matches the request against HTTP methods exactly.
// No transformation of supplied methods or the request method is applied.
type methodCaseExactMatcher []string

// Explicitly apply the default (and current)  method matcher, overrides the router default
func (r *Route) MethodsDefault(methods ...string) *Route
// Explicitly apply the case insensitive method matcher, overrides the router default
func (r *Route) MethodsCaseInsensitive(methods ...string) *Route
// Explicitly apply the exact method matcher, overrides the router default
func (r *Route) MethodsCaseExact(methods ...string) *Route

// Set routeConf value for methodMatcher, for this route, to methodDefaultMatcher
func (r *Route) MatchMethodDefault() *Route
// Set routeConf value for methodMatcher, for this route, to methodCaseInsensitiveMatcher
func (r *Route) MatchMethodCaseInsensitive() *Route
// Set routeConf value for methodMatcher, for this route, to methodCaseExactMatcher
func (r *Route) MatchMethodCaseExact() *Route

// Set default method matcher for the router to methodDefaultMatcher
func (r *Router) MatchMethodDefault() *Router
// Set default method matcher for the router to methodCaseInsensitiveMatcher
func (r *Router) MatchMethodCaseInsensitive() *Router
// Set default method matcher for the router to methodCaseExactMatcher
func (r *Router) MatchMethodCaseExact() *Router


type routeConf struct {
    // ...
    // Holds the default method matcher
    methodMatcher matcher
}

// as well a the helper
func sliceToUpper(slice []string) []string 
```
### Usage
Setting the default method matcher on the router:
```go
r := mux.NewRouter()
r.MatchMethodDefault()          // For the default matcher
r.MatchMethodCaseInsensitive()  // For case insensitive matching
r.MatchMethodCaseExact()        // For exact matching

r.HandleFunc("/", func).Methods("GET") //  will use the default matcher set on the router
```
Applying a specific matcher to a single route and overriding the default method matcher of the router:
```go
r.HandleFunc("/", func).MatchMethodDefault().Methods("GET")
r.HandleFunc("/", func).MatchMethodCaseInsensitive().Methods("GET")
r.HandleFunc("/", func).MatchMethodCaseExact().Methods("GET")
// Not the prefferd method, order of opperations is critcal here. 
// Since the Methods(...) func adds the matcher. 
// Invoking the MatchMethodCaseInsensitive() method after it will have no effect.

// OR, the more preferred method:

r.HandleFunc("/", func).MethodsDefault("GET")
// Explicitly match the methods for this route with the default matcher
r.HandleFunc("/", func).MethodsCaseInsensitive("GET")
// Explicitly match the methods for this route without case sensitivity
r.HandleFunc("/", func).MethodsCaseExact("GET")
// Explicitly match the methods for this route exactly

```

While using the standard ```Methods(...)``` method the default matcher for the router will be used. 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #762 
- Closes #762 

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing
