### PR TITLE
Tests for MethodNotAllowed error

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -2853,7 +2853,177 @@ func Test_copyRouteConf(t *testing.T) {
 	}
 }
 
-func TestMethodNotAllowed(t *testing.T) {
+func TestMethodNotAllowed_diffMethods_bothHandleFuncs(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
+	router := NewRouter()
+
+	router.HandleFunc("/thing", handler).Methods(http.MethodPost)
+	router.HandleFunc("/something", handler).Methods(http.MethodGet)
+
+	w := NewRecorder()
+	req := newRequest(http.MethodGet, "/thing")
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Expected status code 405 (got %d)", w.Code)
+	}
+}
+
+func TestMethodNotAllowed_diffMethods_handleFuncMethods(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
+	router := NewRouter()
+
+	router.HandleFunc("/thing", handler).Methods(http.MethodPost)
+	router.Methods(http.MethodGet).Path("/something").Handler(http.HandlerFunc(handler))
+
+	w := NewRecorder()
+	req := newRequest(http.MethodGet, "/thing")
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Expected status code 405 (got %d)", w.Code)
+	}
+}
+
+func TestMethodNotAllowed_diffMethods_handleFuncPath(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
+	router := NewRouter()
+
+	router.HandleFunc("/thing", handler).Methods(http.MethodPost)
+	router.Path("/something").Methods(http.MethodGet).Handler(http.HandlerFunc(handler))
+
+	w := NewRecorder()
+	req := newRequest(http.MethodGet, "/thing")
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Expected status code 405 (got %d)", w.Code)
+	}
+}
+
+func TestMethodNotAllowed_diffMethods_methodsHandleFunc(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
+	router := NewRouter()
+
+	router.Methods(http.MethodPost).Path("/thing").Handler(http.HandlerFunc(handler))
+	router.HandleFunc("/something", handler).Methods(http.MethodGet)
+
+	w := NewRecorder()
+	req := newRequest(http.MethodGet, "/thing")
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Expected status code 405 (got %d)", w.Code)
+	}
+}
+
+func TestMethodNotAllowed_diffMethods_bothMethods(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
+	router := NewRouter()
+
+	router.Methods(http.MethodPost).Path("/thing").Handler(http.HandlerFunc(handler))
+	router.Methods(http.MethodGet).Path("/something").Handler(http.HandlerFunc(handler))
+
+	w := NewRecorder()
+	req := newRequest(http.MethodGet, "/thing")
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Expected status code 405 (got %d)", w.Code)
+	}
+}
+
+func TestMethodNotAllowed_diffMethods_methodsPath(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
+	router := NewRouter()
+
+	router.Methods(http.MethodPost).Path("/thing").Handler(http.HandlerFunc(handler))
+	router.Path("/something").Methods(http.MethodGet).Handler(http.HandlerFunc(handler))
+
+	w := NewRecorder()
+	req := newRequest(http.MethodGet, "/thing")
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Expected status code 405 (got %d)", w.Code)
+	}
+}
+
+func TestMethodNotAllowed_diffMethods_pathHandleFunc(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
+	router := NewRouter()
+
+	router.Path("/thing").Methods(http.MethodPost).Handler(http.HandlerFunc(handler))
+	router.HandleFunc("/something", handler).Methods(http.MethodGet).Handler(http.HandlerFunc(handler))
+
+	w := NewRecorder()
+	req := newRequest(http.MethodGet, "/thing")
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Expected status code 405 (got %d)", w.Code)
+	}
+}
+
+func TestMethodNotAllowed_diffMethods_pathMethods(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
+	router := NewRouter()
+
+	router.Path("/thing").Methods(http.MethodPost).Handler(http.HandlerFunc(handler))
+	router.Methods(http.MethodGet).Path("/something").Handler(http.HandlerFunc(handler))
+
+	w := NewRecorder()
+	req := newRequest(http.MethodGet, "/thing")
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Expected status code 405 (got %d)", w.Code)
+	}
+}
+
+func TestMethodNotAllowed_diffMethods_bothPath(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
+	router := NewRouter()
+
+	router.Path("/thing").Methods(http.MethodPost).Handler(http.HandlerFunc(handler))
+	router.Path("/something").Methods(http.MethodGet).Handler(http.HandlerFunc(handler))
+
+	w := NewRecorder()
+	req := newRequest(http.MethodGet, "/thing")
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Expected status code 405 (got %d)", w.Code)
+	}
+}
+
+func TestMethodNotAllowed_diffMethods_diffReqMethod(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
+	router := NewRouter()
+
+	router.Path("/thing").Methods(http.MethodPost).Handler(http.HandlerFunc(handler))
+	router.Path("/something").Methods(http.MethodGet).Handler(http.HandlerFunc(handler))
+
+	w := NewRecorder()
+	req := newRequest(http.MethodPost, "/thing")
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Expected status code 405 (got %d)", w.Code)
+	}
+}
+
+func TestMethodNotAllowed_sameMethods(t *testing.T) {
 	handler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
 	router := NewRouter()
 	router.HandleFunc("/thing", handler).Methods(http.MethodGet)

--- a/mux_test.go
+++ b/mux_test.go
@@ -3014,7 +3014,7 @@ func TestMethodNotAllowed_diffMethods_diffReqMethod(t *testing.T) {
 	router.Path("/something").Methods(http.MethodGet).Handler(http.HandlerFunc(handler))
 
 	w := NewRecorder()
-	req := newRequest(http.MethodPost, "/thing")
+	req := newRequest(http.MethodDelete, "/thing")
 
 	router.ServeHTTP(w, req)
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description
Hello!

This pr adds some tests for checking that MethodNotAllowed error is returned correctly in some cases. All new tests are passing in current `main` branch state. But some of them are not passing in `v1.8.1` (b4617d0). 

In released version `404` can be returned instead of `405` when after adding required route, another one with different method and url was added. And also there is a difference in how the route was created. It is also important to make a request to required path with `Method` used in the second route. Sending request with every new and different method that was added after required route with required method will return `404` instead of `405` .  Sending requests with method that hasn't been previously added will work fine and return `405`. Example:

```
func TestMethodNotAllowed_diffMethods_bothHandleFuncs(t *testing.T) {
	handler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
	router := NewRouter()

	router.HandleFunc("/thing", handler).Methods(http.MethodPost)
	router.HandleFunc("/something", handler).Methods(http.MethodGet)

	w := NewRecorder()
	req := newRequest(http.MethodGet, "/thing")

	router.ServeHTTP(w, req)

	if w.Code != http.StatusMethodNotAllowed {
		t.Fatalf("Expected status code 405 (got %d)", w.Code)
	}
}
```
This test is passing in both versions. But next example is not passing in `v1.18.1`:

```
func TestMethodNotAllowed_diffMethods_handleFuncMethods(t *testing.T) {
	handler := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
	router := NewRouter()

	router.HandleFunc("/thing", handler).Methods(http.MethodPost)
	router.Methods(http.MethodGet).Path("/something").Handler(http.HandlerFunc(handler))

	w := NewRecorder()
	req := newRequest(http.MethodGet, "/thing")

	router.ServeHTTP(w, req)

	if w.Code != http.StatusMethodNotAllowed {
		t.Fatalf("Expected status code 405 (got %d)", w.Code)
	}
}
```
The only change here is that `HandleFunc().Methods()` is replaced with `Methods().Path().Handler()`. So different way of creation of router leads to an error. The difference in `v1.18.1` in produced routes was in order of matchers in inner array. Thats want I've mentioned. Wasn't able to identify how this influenced the result. Also I found different ways of how routes can be produced with this error:

```
router.Methods(http.MethodPost).Path("/thing").Handler(http.HandlerFunc(handler))
router.Methods(http.MethodGet).Path("/something").Handler(http.HandlerFunc(handler)) 

router.HandleFunc("/thing", handler).Methods(http.MethodPost)
router.Methods(http.MethodGet).Path("/something").Handler(http.HandlerFunc(handler))

router.Path("/thing").Methods(http.MethodPost).Handler(http.HandlerFunc(handler))
router.Methods(http.MethodGet).Path("/something").Handler(http.HandlerFunc(handler)) 
```


Currently provided tests do not cover cases of route possible varying way of creation except `HandleFunc` . So i added them, trying to check all possible ways of adding routes. 

Despite issue being fixed new tests can ensure that it wont return later. 

If I've missed something, let me know please.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing
