### PR TITLE
add StrictQueryParamSep router option (#781)

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -97,6 +97,10 @@ type routeConf struct {
 	// if true, the the http.Request context will not contain the router
 	omitRouterFromContext bool
 
+	// If true, only ampersands (not semicolons) act as separators for
+	// query-parameter pairs.
+	strictQueryParamSep bool
+
 	// Manager for the variables from host and path.
 	regexp routeRegexpGroup
 
@@ -292,6 +296,24 @@ func (r *Router) OmitRouteFromContext(value bool) *Router {
 // RouterFromRequest will yield nil with this option.
 func (r *Router) OmitRouterFromContext(value bool) *Router {
 	r.omitRouterFromContext = value
+	return r
+}
+
+// StrictQueryParamSep defines which characters act as separators for
+// query-parameter pairs. The initial value is false, but beware: a future
+// version of this library will adopt true for the initial value.
+//
+// When true, only ampersands act as separators for query parameters.
+// This behavior complies with [the URL Living Standard].
+//
+// When false, both ampersands and semicolons act as separators for
+// query-parameter pairs. This contravenes the URL Living Standard and causes
+// interoperability problems that can lead to [security vulnerabilities].
+//
+// [security vulnerabilities]: https://github.com/gorilla/mux/issues/781
+// [the URL Living Standard]: https://url.spec.whatwg.org/#urlencoded-parsing
+func (r *Router) StrictQueryParamSep(value bool) *Router {
+	r.strictQueryParamSep = value
 	return r
 }
 

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -52,7 +52,7 @@ func Test_findFirstQueryKey(t *testing.T) {
 			all, _ := url.ParseQuery(query)
 			for key, want := range all {
 				t.Run(key, func(t *testing.T) {
-					got, ok := findFirstQueryKey(query, key)
+					got, ok := findFirstQueryKey(query, key, false)
 					if !ok {
 						t.Error("Did not get expected key", key)
 					}
@@ -81,7 +81,7 @@ func Benchmark_findQueryKey(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				for key := range all {
-					_, _ = findFirstQueryKey(query, key)
+					_, _ = findFirstQueryKey(query, key, false)
 				}
 			}
 		})

--- a/route.go
+++ b/route.go
@@ -257,8 +257,9 @@ func (r *Route) addRegexpMatcher(tpl string, typ regexpType) error {
 		}
 	}
 	rr, err := newRouteRegexp(tpl, typ, routeRegexpOptions{
-		strictSlash:    r.strictSlash,
-		useEncodedPath: r.useEncodedPath,
+		strictSlash:         r.strictSlash,
+		useEncodedPath:      r.useEncodedPath,
+		strictQueryParamSep: r.strictQueryParamSep,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

Add a router option for disabling semicolons as separators for query-parameter pairs (in accordance with the URL Living Standard). Issue #781 discusses two other viable options; please let me know if you prefer one of them and I'll modify this PR accordingly.

## Related Tickets & Documents

https://github.com/gorilla/mux/issues/781

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [ ] `make verify` is passing
- [x] `make test` is passing
